### PR TITLE
fix when using 'logger()'

### DIFF
--- a/src/Observers/LogObserver.php
+++ b/src/Observers/LogObserver.php
@@ -21,9 +21,11 @@ class LogObserver
 
             /** @var array $config */
             $config    = config('laradumps.level_log_colors_map');
-            
-            if ($message->level == 'debug') $message->level = 'info';
-            
+
+            if ($message->level == 'debug') {
+                $message->level = 'info';
+            }
+
             $log       = [
                 'message'     => $message->message,
                 'level'       => $message->level,

--- a/src/Observers/LogObserver.php
+++ b/src/Observers/LogObserver.php
@@ -21,6 +21,9 @@ class LogObserver
 
             /** @var array $config */
             $config    = config('laradumps.level_log_colors_map');
+            
+            if ($message->level == 'debug') $message->level = 'info';
+            
             $log       = [
                 'message'     => $message->message,
                 'level'       => $message->level,


### PR DESCRIPTION
the 'logger' helper by default uses the 'debug' level. For that case, Laradumps will consider it the level log as info