### PR TITLE
Send livewire components to Livewire screen

### DIFF
--- a/src/Observers/LivewireObserver.php
+++ b/src/Observers/LivewireObserver.php
@@ -42,9 +42,11 @@ class LivewireObserver
                 $data['component']   = get_class($component);
                 $data['id']          = $component->id;
 
-                $dumps = new LaraDumps();
+                $dumps = new LaraDumps(notificationId: $data['view']);
 
                 $dumps->send(new LivewirePayload($data));
+
+                $dumps->toScreen('Livewire');
             });
         }
     }


### PR DESCRIPTION
This PR causes LaraDumps to send livewire requests to the Livewire screen

![image](https://user-images.githubusercontent.com/33601626/174851938-db0d4931-08b5-44f8-8a2b-8d971f266cee.png)
