### PR TITLE
Check if you forgot any ds() in your files, run ... in your pipeline

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "symfony/var-dumper": "^5.4 | ^6.0",
         "nunomaduro/larastan": "^1.0 | ^2.1",
         "friendsofphp/php-cs-fixer": "^3.8",
-        "pestphp/pest": "^1.21"
+        "pestphp/pest": "^1.21",
+        "nunomaduro/termwind": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6aad385d49a3c03c52034e041f96834",
+    "content-hash": "99855a7260e225e716610fa5758e6f8e",
     "packages": [],
     "packages-dev": [
         {
@@ -2668,6 +2668,92 @@
                 }
             ],
             "time": "2022-06-04T14:21:33+00:00"
+        },
+        {
+            "name": "nunomaduro/termwind",
+            "version": "v1.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nunomaduro/termwind.git",
+                "reference": "8ae79be19eddeac25e6bf5b9e1696de87d4f1556"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/8ae79be19eddeac25e6bf5b9e1696de87d4f1556",
+                "reference": "8ae79be19eddeac25e6bf5b9e1696de87d4f1556",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^8.0",
+                "symfony/console": "^5.3.0|^6.0.0"
+            },
+            "require-dev": {
+                "ergebnis/phpstan-rules": "^1.0.",
+                "illuminate/console": "^8.0|^9.0",
+                "illuminate/support": "^8.0|^9.0",
+                "pestphp/pest": "^1.21.0",
+                "pestphp/pest-plugin-mock": "^1.0",
+                "phpstan/phpstan": "^1.4.6",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "styleci/cli": "^1.2.0",
+                "symfony/var-dumper": "^5.2.7|^6.0.0",
+                "thecodingmachine/phpstan-strict-rules": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Termwind\\Laravel\\TermwindServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php"
+                ],
+                "psr-4": {
+                    "Termwind\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Its like Tailwind CSS, but for the console.",
+            "keywords": [
+                "cli",
+                "console",
+                "css",
+                "package",
+                "php",
+                "style"
+            ],
+            "support": {
+                "issues": "https://github.com/nunomaduro/termwind/issues",
+                "source": "https://github.com/nunomaduro/termwind/tree/v1.11.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/xiCO2k",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-06-17T12:26:22+00:00"
         },
         {
             "name": "orchestra/testbench",

--- a/config/laradumps.php
+++ b/config/laradumps.php
@@ -189,10 +189,11 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    |  CI
+    |  CI Check
     |--------------------------------------------------------------------------
     |
-    | WIP
+    | Check if you forgot any ds() in your files,
+    | run "php artisan ds:check" in your pipeline
     |
     */
 

--- a/config/laradumps.php
+++ b/config/laradumps.php
@@ -186,4 +186,33 @@ return [
     */
 
     'sleep' => env('DS_SLEEP'),
+
+    /*
+    |--------------------------------------------------------------------------
+    |  CI
+    |--------------------------------------------------------------------------
+    |
+    | WIP
+    |
+    */
+
+    'ci_check' => [
+        'directories' => [
+            base_path('app'),
+            base_path('routes'),
+            resource_path(),
+        ],
+        'ignore_line_when_contains_text' => [
+        ],
+        'text_to_search' => [
+            ' ds(',
+            ' dsd(',
+            ' ds1(',
+            ' ds2(',
+            ' ds3(',
+            ' ds4(',
+            ' ds5(',
+            '@ds(',
+        ],
+    ],
 ];

--- a/resources/views/output.blade.php
+++ b/resources/views/output.blade.php
@@ -1,0 +1,5 @@
+<div class="space-x-1 mx-2 mb-1">
+    <code line="{{ $line }}" start-line="{{ $line - 2 }}">
+        {{ $content }}
+    </code>
+</div>

--- a/resources/views/summary.blade.php
+++ b/resources/views/summary.blade.php
@@ -1,0 +1,23 @@
+<div class="mx-1">
+    @if(!$error)
+        No ds() found.
+    @endif
+    <div class="flex space-x-1">
+        <span class="flex-1 content-repeat-[─] text-gray"></span>
+    </div>
+    <div>
+        <span>
+            <div class="flex space-x-2 mx-1 mb-1">
+                @if($error)
+                    <span class="p-2 bg-red text-white">
+                        [ERROR] Found {{ $total.' '.str('error')->plural($total) }} / {{ $totalFiles }} {{ str('file')->plural($totalFiles) }}
+                    </span>
+                @else
+                    <span class="px-2 bg-green text-white uppercase font-bold">
+                        ✓ SUCCESS
+                    </span>
+                @endif
+            </div>
+        </span>
+    </div>
+</div>

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Commands;
+
+use Illuminate\Console\Command;
+use LaraDumps\LaraDumps\Support\IdeHandle;
+use Symfony\Component\Finder\Finder;
+
+use function Termwind\{render, renderUsing};
+
+class CheckCommand extends Command
+{
+    protected $signature = 'ds:check';
+
+    protected $description = 'Check if you forgot any ds() in your files';
+
+    public function handle(): int
+    {
+        /** @var array<string>|string $directories */
+        $directories = config('laradumps.ci_check.directories');
+
+        $ignoreLineWhenContainsText = config('laradumps.ci_check.ignore_line_when_contains_text');
+
+        $textToSearch = config('laradumps.ci_check.text_to_search');
+
+        renderUsing($this->output);
+
+        $matches = [];
+
+        $finder = new Finder();
+
+        $finder->files()->in($directories);
+
+        $progressBar = $this->output->createProgressBar($finder->count());
+
+        $this->output->writeln('');
+
+        foreach ($finder as $file) {
+            $progressBar->advance();
+
+            /** @var string[] $contents */
+            $contents = file($file->getRealPath());
+
+            foreach ($contents as $line => $lineContent) {
+                $contains  = false;
+                $ignore    = false;
+
+                /** @var string[] $ignoreLineWhenContainsText */
+                foreach ($ignoreLineWhenContainsText as $text) {
+                    if (strpos(strtolower($lineContent), strtolower($text))) {
+                        $ignore = true;
+
+                        break;
+                    }
+                }
+
+                /** @var string[] $textToSearch */
+                foreach ($textToSearch as $search) {
+                    if (strpos($lineContent, $search)) {
+                        $contains = true;
+
+                        break;
+                    }
+                }
+
+                if ($contains && !$ignore) {
+                    $matches[] = $this->saveContent($file, $lineContent, $line);
+                }
+            }
+        }
+
+        $this->output->writeln('');
+        $this->output->writeln('');
+
+        foreach ($matches as $iterator => $content) {
+            $this->output->writeln(
+                ' ' . ($iterator + 1)
+                . '<href=' . $content['link'] . '>  '
+                . $content['realPath']
+                . ':'
+                . $content['line']
+                . '</>'
+            );
+
+            render(
+                view('laradumps::output', [
+                    'line'    => $content['line'],
+                    'content' => $content['content'],
+                ])
+            );
+        }
+
+        $progressBar->finish();
+
+        $this->output->writeln('');
+
+        if (($total = count($matches)) > 0) {
+            render(
+                view('laradumps::summary', [
+                    'error'      => true,
+                    'total'      => $total,
+                    'totalFiles' => collect($matches)->unique('realPath')->count(),
+                ])
+            );
+
+            return Command::FAILURE;
+        }
+
+        render(
+            view('laradumps::summary', [
+                'error' => false,
+                'total' => 0,
+            ])
+        );
+
+        return Command::SUCCESS;
+    }
+
+    private function saveContent(\SplFileInfo $file, string $lineContent, int $line): array
+    {
+        /** @var array $fileContents */
+        $fileContents = file($file->getRealPath());
+
+        $partialContent = $fileContents[$line - 2]  ?? '';
+        $partialContent .= $fileContents[$line - 1] ?? '';
+
+        $partialContent .= $lineContent;
+        $partialContent .= $fileContents[$line + 1] ?? '';
+
+        return [
+            'line'     => $line + 1,
+            'file'     => str_replace(base_path() . '/', '', $file->getRealPath()),
+            'realPath' => 'file:///' . $file->getRealPath(),
+            'link'     => IdeHandle::makeFileHandler($file->getRealPath(), $line + 1),
+            'content'  => $partialContent,
+        ];
+    }
+}

--- a/src/LaraDumpsServiceProvider.php
+++ b/src/LaraDumpsServiceProvider.php
@@ -5,6 +5,7 @@ namespace LaraDumps\LaraDumps;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\{ServiceProvider, Str};
+use LaraDumps\LaraDumps\Commands\CheckCommand;
 use LaraDumps\LaraDumps\Observers\{LivewireObserver, LogObserver, QueryObserver};
 use LaraDumps\LaraDumps\Payloads\QueryPayload;
 
@@ -31,6 +32,12 @@ class LaraDumpsServiceProvider extends ServiceProvider
         app(LogObserver::class)->register();
         app(QueryObserver::class)->register();
         app(LivewireObserver::class)->register();
+
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'laradumps');
+
+        if ($this->app->runningInConsole()) {
+            $this->commands([CheckCommand::class]);
+        }
     }
 
     public function register(): void

--- a/src/Support/IdeHandle.php
+++ b/src/Support/IdeHandle.php
@@ -41,7 +41,7 @@ class IdeHandle
         ];
     }
 
-    public static function makeFileHandler(string $file, string $line): string
+    public static function makeFileHandler(string $file, string|int $line): string
     {
         /** @var string $preferredIde */
         $preferredIde = config('laradumps.preferred_ide');

--- a/tests/CheckCommandTest.php
+++ b/tests/CheckCommandTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    $this->view          = getLaravelDir() . 'resources/views/view.blade.php';
+    $this->controller    = getLaravelDir() . 'app/Http/Controllers/LaraDumpsController.php';
+});
+
+it('display "No ds() found" when not ds found', function () {
+    if (file_exists($this->view)) {
+        File::delete($this->view);
+    }
+
+    if (file_exists($this->controller)) {
+        File::delete($this->controller);
+    }
+
+    $this->artisan('ds:check')
+        ->expectsOutputToContain('No ds() found.');
+});
+
+it('displays error when found on resources path', function () {
+    createBlade($this);
+
+    $this->assertFileExists($this->view);
+
+    Config::set('laradumps.ci_check.directories', [
+        resource_path(),
+    ]);
+
+    $this->artisan('ds:check')
+        ->expectsOutputToContain('@ds(\'Hello\')')
+        ->expectsOutputToContain('Found 1 error / 1 file')
+        ->assertFailed();
+});
+
+it('does not display error when found on resources path when not specified in config', function () {
+    createBlade($this);
+
+    $this->assertFileExists($this->view);
+
+    Config::set('laradumps.ci_check.directories', [
+        base_path('app'),
+    ]);
+
+    $this->artisan('ds:check')
+        ->expectsOutputToContain('No ds() found.')
+        ->assertSuccessful();
+});
+
+it('displays error when found on controller', function () {
+    createControllerClass($this);
+
+    $this->assertFileExists($this->controller);
+
+    Config::set('laradumps.ci_check.directories', [
+        base_path('app'),
+    ]);
+
+    $this->artisan('ds:check')
+        ->expectsOutputToContain('ds(\'Hello from Controller\')->label(\'label\')')
+        ->expectsOutputToContain('Found 1 error / 1 file')
+        ->assertFailed();
+});
+
+it('does displays error when found on controller when not specified in config', function () {
+    if (file_exists($this->view)) {
+        File::delete($this->view);
+    }
+
+    createControllerClass($this);
+
+    $this->assertFileExists($this->controller);
+
+    Config::set('laradumps.ci_check.directories', [
+        resource_path(),
+    ]);
+
+    $this->artisan('ds:check')
+        ->doesntExpectOutputToContain('error')
+        ->expectsOutputToContain('No ds() found.')
+        ->assertSuccessful();
+});
+
+it('displays errors when found on controller and resources path', function () {
+    createBlade($this);
+    createControllerClass($this);
+
+    $this->assertFileExists($this->view);
+    $this->assertFileExists($this->controller);
+
+    Config::set('laradumps.ci_check.directories', [
+        base_path('app'),
+        resource_path(),
+    ]);
+
+    $this->artisan('ds:check')
+        ->expectsOutputToContain('@ds(\'Hello\')')
+        ->expectsOutputToContain('ds(\'Hello from Controller\')->label(\'label\')')
+        ->expectsOutputToContain('Found 2 errors / 2 files')
+        ->assertFailed();
+});
+
+it('ignore an error when encountering specific text on the line', function () {
+    createBlade($this);
+    createControllerClass($this);
+
+    $this->assertFileExists($this->view);
+    $this->assertFileExists($this->controller);
+
+    Config::set('laradumps.ci_check.ignore_line_when_contains_text', [
+        'Hello from',
+    ]);
+
+    $this->artisan('ds:check')
+        ->expectsOutputToContain('@ds(\'Hello\')')
+        ->doesntExpectOutputToContain('ds(\'Hello from Controller\')->label(\'label\')')
+        ->expectsOutputToContain('Found 1 error / 1 file')
+        ->assertFailed();
+});
+
+function createBlade($self): void
+{
+    $blade = '<div>@ds(\'Hello\') </div>';
+
+    file_put_contents($self->view, $blade);
+}
+
+function createControllerClass($self): void
+{
+    $html = <<<'PHP'
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Routing\Controller as BaseController;
+
+class LaraDumpsController extends BaseController
+{
+    public function index()
+    {
+        ds('Hello from Controller')->label('label');
+    }
+}
+PHP;
+
+    file_put_contents($self->controller, $html);
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,3 +3,8 @@
 use LaraDumps\LaraDumps\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
+
+function getLaravelDir(): string
+{
+    return __DIR__ . '/../vendor/orchestra/testbench-core/laravel/';
+}


### PR DESCRIPTION
This PR adds the possibility to stop the pipeline in case you forget any ds in the middle of the files.

Example:

`composer.json`
```php
"scripts": {
   "ds:check": "@php artisan ds:check",
   "verify": [
         "@ds:check",
         // ..
   ],
}
```

Run `composer verify` in you pipeline

### Error
![image](https://user-images.githubusercontent.com/33601626/175782177-6784e6fc-30e7-45d5-b2da-47d5048dc888.png)

### Success
![image](https://user-images.githubusercontent.com/33601626/175782320-83fa50b2-3696-4069-8a95-25b3325c5712.png)

