### PR TITLE
Rename parameter to splitDiff

### DIFF
--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -228,18 +228,15 @@ class LaraDumps
     }
 
     /**
-     * Check the difference between two texts
-     * @param mixed $first
-     * @param mixed $second
+     * @param mixed $argument
      * @param boolean $splitDiff Outputs comparison result in 2 rows (original/diff).
      * @return LaraDumps
      */
-    public function diff(mixed $first, mixed $second, bool $splitDiff = false): LaraDumps
+    public function diff(mixed $argument, bool $splitDiff = false): LaraDumps
     {
-        $first  = is_array($first) ? json_encode($first) : $first;
-        $second = is_array($second) ? json_encode($second) : $second;
+        $argument  = is_array($argument) ? json_encode($argument) : $argument;
 
-        $payload = new DiffPayload($first, $second, $splitDiff);
+        $payload = new DiffPayload($argument, $splitDiff);
         $this->send($payload);
 
         return $this;

--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -229,14 +229,17 @@ class LaraDumps
 
     /**
      * Check the difference between two texts
-     *
+     * @param mixed $first
+     * @param mixed $second
+     * @param boolean $splitDiff Outputs comparison result in 2 rows (original/diff).
+     * @return LaraDumps
      */
-    public function diff(mixed $first, mixed $second, bool $col = false): LaraDumps
+    public function diff(mixed $first, mixed $second, bool $splitDiff = false): LaraDumps
     {
         $first  = is_array($first) ? json_encode($first) : $first;
         $second = is_array($second) ? json_encode($second) : $second;
 
-        $payload = new DiffPayload($first, $second, $col);
+        $payload = new DiffPayload($first, $second, $splitDiff);
         $this->send($payload);
 
         return $this;

--- a/src/Payloads/DiffPayload.php
+++ b/src/Payloads/DiffPayload.php
@@ -7,7 +7,7 @@ class DiffPayload extends Payload
     public function __construct(
         public mixed $first,
         public mixed $second,
-        public bool $col,
+        public bool $splitDiff,
     ) {
     }
 
@@ -22,7 +22,7 @@ class DiffPayload extends Payload
         return [
             'first'  => $this->first,
             'second' => $this->second,
-            'col'    => $this->col,
+            'col'    => $this->splitDiff,
         ];
     }
 }

--- a/src/Payloads/DiffPayload.php
+++ b/src/Payloads/DiffPayload.php
@@ -5,8 +5,7 @@ namespace LaraDumps\LaraDumps\Payloads;
 class DiffPayload extends Payload
 {
     public function __construct(
-        public mixed $first,
-        public mixed $second,
+        public mixed $argument,
         public bool $splitDiff,
     ) {
     }
@@ -20,9 +19,8 @@ class DiffPayload extends Payload
     public function content(): array
     {
         return [
-            'first'  => $this->first,
-            'second' => $this->second,
-            'col'    => $this->splitDiff,
+            'argument'  => $this->argument,
+            'splitDiff' => $this->splitDiff,
         ];
     }
 }


### PR DESCRIPTION
Hi Luan,

As mentioned by Tio Jobs in his review, the parameter name `col` can be confusing.

I propose to rename it to `splitDiff`, as it controls whether the result will be split in two lines (original/diff).

Greetings and thanks,

Dan