### PR TITLE
[1.0] Contains with case sensitive and whole word search

### DIFF
--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -133,13 +133,19 @@ class LaraDumps
     }
 
     /**
-     * Search if content contains string
+     * Checks if content contains string.
      *
+     * @param string $content
+     * @param boolean $caseSensitive Search is case sensitive
+     * @param boolean $wholeWord Search for the whole words
+     * @return LaraDumps
      */
-    public function contains(string $content): LaraDumps
+    public function contains(string $content, bool $caseSensitive = false, bool $wholeWord = false): LaraDumps
     {
         $payload = new ValidateStringPayload('contains');
-        $payload->setContent($content);
+        $payload->setContent($content)
+            ->setCaseSensitive($caseSensitive)
+            ->setWholeWord($wholeWord);
 
         $this->send($payload);
 

--- a/src/Payloads/ValidateStringPayload.php
+++ b/src/Payloads/ValidateStringPayload.php
@@ -6,6 +6,10 @@ class ValidateStringPayload extends Payload
 {
     protected string $content;
 
+    protected bool $caseSensitive = false;
+
+    protected bool $wholeWord = false;
+
     public function __construct(
         public string $type
     ) {
@@ -16,18 +20,34 @@ class ValidateStringPayload extends Payload
         return 'validate';
     }
 
-    /** @return array<string> */
+    /** @return array<string|boolean> */
     public function content(): array
     {
         return [
-            'type'    => $this->type,
-            'content' => $this->content ?? '',
+            'type'              => $this->type,
+            'content'           => $this->content ?? '',
+            'is_case_sensitive' => $this->caseSensitive,
+            'is_whole_word'     => $this->wholeWord,
         ];
     }
 
     public function setContent(string $content): self
     {
         $this->content = $content;
+
+        return $this;
+    }
+
+    public function setCaseSensitive(bool $caseSensitive = true): self
+    {
+        $this->caseSensitive = $caseSensitive;
+
+        return $this;
+    }
+
+    public function SetWholeWord(bool $wholeWord = true): self
+    {
+        $this->wholeWord = $wholeWord;
 
         return $this;
     }


### PR DESCRIPTION
Hi Luan,

This PR adds the possibility to toggle `case sensitive` and `whole word` search in `ds()->contains()`.

**Motivation**

I believe in certain cases, a very permissive `contains()` could lead the user to false positives.

In the example below, the user would like to check for "Mariana" as a full word and not part of  "Marianatown".

```php 
$json = '{"name":"Paulo", "city":"Marianatown"}';

ds($json)->contains('Mariana'); //would produce ✅ Text contains
 ```
In languages like German, capitalizing nouns is important. `Elf` means the creature from folk stories, while `elf` means 11.

```php 
$json = '{"name":"Haleth", "nature":"Elf"}';

ds($json)->contains('elf'); //would produce ✅ Text contains
 ```

This PR introduces two parameters to control case sensitive and whole word search.

```php
$json = '{"name":"Mariana", "country":"Brazil"}';

//Will not match "Brazil"
ds($json)->contains('brazil', caseSensitive: true);

//No match for "Maria" in "Mariana" 
ds($json)->contains('Maria', wholeWord: true);
```
--- 

Please let me know if additional modifications are required!

Greetings and thanks

Dan