### PR TITLE
Enhance ds:check for dsq, ds-macro, commented ds and dsAutoClearOnPageReload directive

### DIFF
--- a/config/laradumps.php
+++ b/config/laradumps.php
@@ -225,6 +225,7 @@ return [
     'ci_check' => [
         'directories' => [
             base_path('app'),
+            base_path('resources'),
         ],
         'ignore_line_when_contains_text' => [
         ],

--- a/config/laradumps.php
+++ b/config/laradumps.php
@@ -224,19 +224,19 @@ return [
 
     'ci_check' => [
         'directories' => [
-            base_path('config'),
+            base_path('app'),
         ],
         'ignore_line_when_contains_text' => [
         ],
         'text_to_search' => [
-            ' ds(',
-            ' dsd(',
-            ' ds1(',
-            ' ds2(',
-            ' ds3(',
-            ' ds4(',
-            ' ds5(',
-            '@ds(',
+            'ds(',
+            'dsq(',
+            'dsd(',
+            'ds1(',
+            'ds2(',
+            'ds3(',
+            'ds4(',
+            'ds5(',
         ],
     ],
 

--- a/config/laradumps.php
+++ b/config/laradumps.php
@@ -237,6 +237,7 @@ return [
             'ds3(',
             'ds4(',
             'ds5(',
+            'dsAutoClearOnPageReload',
         ],
     ],
 

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -56,7 +56,13 @@ class CheckCommand extends Command
 
                 /** @var string[] $textToSearch */
                 foreach ($textToSearch as $search) {
-                    if (strpos($lineContent, $search)) {
+                    $search = ' ' . ltrim($search);// mantaining compatiblity with V1.0.2;
+
+                    if (strpos($lineContent, $search)
+                        || strpos($lineContent, '@' . ltrim($search))
+                        || strpos($lineContent, '//' . ltrim($search))
+                        || strpos($lineContent, '->' . ltrim($search))
+                    ) {
                         $contains = true;
 
                         break;

--- a/tests/CheckCommandTest.php
+++ b/tests/CheckCommandTest.php
@@ -121,7 +121,7 @@ it('does displays error when found on controller when not specified in config', 
         ->assertSuccessful();
 })->requiresLaravel9();
 
-it('will not match a partial funcion', function () {
+it('will not match a partial function', function () {
     if (File::exists($this->view)) {
         File::delete($this->view);
     }


### PR DESCRIPTION
Hi Luan,

This PR enhances the `php artisan ds:check` and does not introduce any breaking change.

## Main changes

- The `dsq()` and `@dsAutoClearOnPageReload`  are now included in the functions to be checked;
- Commented  calls `//ds()` will produce now produce a  "ds() found error";
- Macro DS calls `User::query()->where('id', 20)->ds()->get();` also produces a  "ds() found error";
- Changed the `ci_check`.`directories` to  include only `base_path('app')` and ` base_path('resources')`;
- Removed the spaces on `ci_check`.`text_to_search` for better user experience;
- Test is now checking for functions; whenever  a new shortcut is created, it must be included there.
 
## Problem

Currently, `ds:check` is not detecting the commented calls and macro calls.

Even though commented `ds()` calls would  not produce any problem, having them in the final product can be seen as a "less professional" code quality.

When it comes to the Blade directive `dsAutoClearOnPageReload`,  the documentation code snippet show that the app mode should be checked, avoiding leaking the directive in production mode. That is good but In my point of view, there is no need to send this piece of code to production.

<img width="371" alt="2 antes" src="https://user-images.githubusercontent.com/79267265/179362064-b32a60a5-7c74-4b1c-963d-a17a83a45663.png">

<img width="371" alt="2 antes" src="https://user-images.githubusercontent.com/79267265/179361961-b0fc9fe9-a31f-428c-9db4-ed298ec71982.png">

## Result

<img width="371" alt="2 antes" src="https://user-images.githubusercontent.com/79267265/179363291-b8d94c3f-6251-4abf-8f89-0e09fd920a4a.png">

<img width="371" alt="2 antes" src="https://user-images.githubusercontent.com/79267265/179363302-7f438f7b-420c-44ce-9be8-8853ef3b995e.png">


Please let me know if changes are required.

Greetings and thanks,

Dan
