### PR TITLE
Fix application showing livewire failed validation even disabled in settings

### DIFF
--- a/src/Observers/LivewireFailedValidationObserver.php
+++ b/src/Observers/LivewireFailedValidationObserver.php
@@ -14,6 +14,10 @@ class LivewireFailedValidationObserver
     {
         if (class_exists(\Livewire\Livewire::class)) {
             \Livewire\Livewire::listen('failed-validation', function (Validator $validator, $component) {
+                if (!$this->isEnabled()) {
+                    return;
+                }
+
                 $failedRules = [];
 
                 foreach ($validator->getMessageBag()->messages() as $rule => $messages) {

--- a/src/Observers/LivewireFailedValidationObserver.php
+++ b/src/Observers/LivewireFailedValidationObserver.php
@@ -5,8 +5,7 @@ namespace LaraDumps\LaraDumps\Observers;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Validator;
 use LaraDumps\LaraDumps\LaraDumps;
-use LaraDumps\LaraDumps\Payloads\{LivewirePayload, TablePayload};
-use LaraDumps\LaraDumps\Support\{Dumper, IdeHandle};
+use LaraDumps\LaraDumps\Payloads\TablePayload;
 use ReflectionClass;
 
 class LivewireFailedValidationObserver


### PR DESCRIPTION
Hey, @luanfreitasdev 

Laradumps was ignoring the user's livewire failed validation config.

I added the check that was missing and removed some class imports that were not being used.