### PR TITLE
hotfix: fixed handle click on LaraDumps

### DIFF
--- a/config/laradumps.php
+++ b/config/laradumps.php
@@ -197,7 +197,8 @@ return [
             'handler'        => 'vscode://vscode-remote/',
             'line_separator' => ':',
             'local_path'     => 'wsl+' . env('DS_PREFERRED_WSL_DISTRO', 'Ubuntu20.04LTS'),
-            'remote_path'    => '/var/www/html',
+            'remote_path'    => env('DS_REMOTE_PATH', null),
+            'work_dir'       => env('DS_WORKDIR', '/var/www/html'),
         ],
     ],
 

--- a/src/Support/IdeHandle.php
+++ b/src/Support/IdeHandle.php
@@ -52,13 +52,14 @@ class IdeHandle
         $ide        = $handlers[$preferredIde] ?? $handlers['vscode'];
         $localPath  = $ide['local_path']       ?? null;
         $remotePath = $ide['remote_path']      ?? null;
+        $workDir    = $ide['work_dir']         ?? null;
 
         if (!empty($localPath)) {
             $file      = $localPath . $file;
         }
 
         if (!empty($remotePath)) {
-            $file = str_replace($remotePath, '', strval($file));
+            $file = str_replace($workDir, $remotePath, strval($file));
         }
 
         if (!empty($ide['line_separator'])) {


### PR DESCRIPTION
## When we tried to click on LaraDumps app handle link using windows on wsl+docker, exhibited an error on VS Code.

Now, we fixed it adding new .env variables and fixing the replace on IdeHandle.php file.


**Follow the image:**
![handler-error](https://user-images.githubusercontent.com/16943171/183095119-d45814d9-6db8-42d2-9f0f-6cb8d050de3e.png)


**New variable added:**
![env-variablespng](https://user-images.githubusercontent.com/16943171/183095485-3715cc64-02f5-444e-93b5-07f77ffda59e.png)


**Replacing on IdeHandle.php:**
![idehandle](https://user-images.githubusercontent.com/16943171/183095710-f5779428-f835-48b8-9f17-7a27324da51a.png)


**laradumps.php (config):**
![laradumps-config](https://user-images.githubusercontent.com/16943171/183096123-3ac05bee-5bc3-4ae1-8d74-6fffb38c01a7.png)
