### PR TITLE
Improvements ds:init (config file delete and IDEs from package config) & Livewire Events

### DIFF
--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -12,7 +12,7 @@ class InitCommand extends Command
     use RenderAscii;
     use UpdateEnv;
 
-    protected $signature = 'ds:init {--no-interaction?} {--host=} {--port=} {--send_queries=} {--send_logs=} {--send_livewire=}     {--livewire_validation=}  {--livewire_autoclear=} {--auto_invoke=} {--ide=}';
+    protected $signature = 'ds:init {--no-interaction?} {--host=} {--port=} {--send_queries=} {--send_logs=} {--send_livewire=} {--livewire_events=}{--livewire_validation=}  {--livewire_autoclear=} {--auto_invoke=} {--ide=}';
 
     protected $description = 'Initialize LaraDumps configuration';
 
@@ -31,6 +31,7 @@ class InitCommand extends Command
             ->setQueries()
             ->setLogs()
             ->setLivewire()
+            ->setLivewireEvents()
             ->setLivewireValidation()
             ->setLivewireAutoClear()
             ->setAutoInvoke()
@@ -80,6 +81,7 @@ class InitCommand extends Command
                     . ' --send_queries=' . (config('laradumps.send_queries') ? 'true' : 'false')
                     . ' --send_logs=' . (config('laradumps.send_log_applications') ? 'true' : 'false')
                     . ' --send_livewire=' . (config('laradumps.send_livewire_components') ? 'true' : 'false')
+                    . ' --livewire_events=' . (config('laradumps.send_livewire_events') ? 'true' : 'false')
                     . ' --livewire_validation=' . (config('laradumps.send_livewire_failed_validation.enabled') ? 'true' : 'false')
                     . ' --livewire_autoclear=' . (config('laradumps.auto_clear_on_page_reload') ? 'true' : 'false')
                     . ' --auto_invoke=' . (config('laradumps.auto_invoke_app') ? 'true' : 'false')
@@ -192,6 +194,22 @@ class InitCommand extends Command
 
         config()->set('laradumps.send_livewire_components', boolval($sendLivewire));
         $this->updateEnv('DS_SEND_LIVEWIRE_COMPONENTS', ($sendLivewire ? 'true' : 'false'));
+
+        return $this;
+    }
+
+    private function setLivewireEvents(): self
+    {
+        $sendLivewireEvents =  $this->option('livewire_events');
+
+        if (empty($sendLivewireEvents) && $this->isInteractive) {
+            $sendLivewireEvents = $this->confirm('Allow dumping <comment>Livewire Events</comment> to the App?', true);
+        }
+
+        $sendLivewireEvents = filter_var($sendLivewireEvents, FILTER_VALIDATE_BOOLEAN);
+
+        config()->set('laradumps.send_livewire_events', boolval($sendLivewireEvents));
+        $this->updateEnv('DS_LIVEWIRE_EVENTS', ($sendLivewireEvents ? 'true' : 'false'));
 
         return $this;
     }

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -265,7 +265,7 @@ class InitCommand extends Command
 
         if (empty($ide) && $this->isInteractive) {
             $ide = $this->choice(
-                'What is your preferred for this project?',
+                'What is your preferred IDE for this project?',
                 $ideList,
                 'phpstorm'
             );

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -247,6 +247,7 @@ class InitCommand extends Command
     private function ideConfigList(): array
     {
         $configFilePath = __DIR__ . '/../../config/laradumps.php';
+        $configFilePath = str_replace('/', DIRECTORY_SEPARATOR, $configFilePath);
 
         if (!File::exists($configFilePath)) {
             throw new Exception("LaraDumps config file doesn't exist.");

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -44,7 +44,7 @@ class InitCommand extends Command
     private function publishConfig(): void
     {
         if ($this->isInteractive  && File::exists(config_path('laradumps.php'))) {
-            if ($this->confirm('The file <comment>laradumps.php</comment> already exists. Delete it?') === true) {
+            if ($this->confirm('The config file <comment>laradumps.php</comment> already exists. Delete it?') === true) {
                 File::delete(config_path('laradumps.php'));
             }
         }

--- a/tests/InitCommandTest.php
+++ b/tests/InitCommandTest.php
@@ -5,7 +5,7 @@ use Illuminate\Support\Facades\File;
 it('publishes the config file', function () {
     $configFile = config_path('laradumps.php');
 
-    if (!File::exists($configFile)) {
+    if (File::exists($configFile)) {
         File::delete($configFile);
     }
 
@@ -43,6 +43,7 @@ it('updates the config non-interactively', function () {
 
 it('updates the config through the wizard', function () {
     $this->artisan('ds:init')
+        ->expectsQuestion('The file <comment>laradumps.php</comment> already exists. Delete it?', true)
         ->expectsQuestion('Select the App host address', '0.0.0.1')
         ->expectsQuestion('Enter the App Port', '1212')
         ->expectsQuestion('Allow dumping <comment>SQL Queries</comment> to the App?', true)
@@ -64,6 +65,7 @@ it('updates the config through the wizard', function () {
     expect(config('laradumps.preferred_ide'))->toBe('phpstorm');
 
     $this->artisan('ds:init')
+        ->expectsQuestion('The file <comment>laradumps.php</comment> already exists. Delete it?', true)
         ->expectsQuestion('Select the App host address', 'other')
         ->expectsQuestion('Enter the App Host', '5.7.9.11')
         ->expectsQuestion('Enter the App Port', '5555')

--- a/tests/InitCommandTest.php
+++ b/tests/InitCommandTest.php
@@ -52,7 +52,7 @@ it('updates the config through the wizard', function () {
         ->expectsQuestion('Allow dumping <comment>Livewire failed validation</comment> to the App?', true)
         ->expectsQuestion('Enable <comment>Auto-clear</comment> APP History on page reload?', true)
         ->expectsQuestion('Would you like to invoke the App window on every Dump?', true)
-        ->expectsQuestion('What is your preferred for this project?', 'phpstorm');
+        ->expectsQuestion('What is your preferred IDE for this project?', 'phpstorm');
 
     expect(config('laradumps.host'))->toBe('0.0.0.1');
     expect(config('laradumps.port'))->toBe('1212');
@@ -75,7 +75,7 @@ it('updates the config through the wizard', function () {
         ->expectsQuestion('Allow dumping <comment>Livewire failed validation</comment> to the App?', false)
         ->expectsQuestion('Enable <comment>Auto-clear</comment> APP History on page reload?', false)
         ->expectsQuestion('Would you like to invoke the App window on every Dump?', false)
-        ->expectsQuestion('What is your preferred for this project?', 'atom');
+        ->expectsQuestion('What is your preferred IDE for this project?', 'atom');
 
     expect(config('laradumps.host'))->toBe('5.7.9.11');
     expect(config('laradumps.port'))->toBe('5555');

--- a/tests/InitCommandTest.php
+++ b/tests/InitCommandTest.php
@@ -43,7 +43,7 @@ it('updates the config non-interactively', function () {
 
 it('updates the config through the wizard', function () {
     $this->artisan('ds:init')
-        ->expectsQuestion('The file <comment>laradumps.php</comment> already exists. Delete it?', true)
+        ->expectsQuestion('The config file <comment>laradumps.php</comment> already exists. Delete it?', true)
         ->expectsQuestion('Select the App host address', '0.0.0.1')
         ->expectsQuestion('Enter the App Port', '1212')
         ->expectsQuestion('Allow dumping <comment>SQL Queries</comment> to the App?', true)
@@ -65,7 +65,7 @@ it('updates the config through the wizard', function () {
     expect(config('laradumps.preferred_ide'))->toBe('phpstorm');
 
     $this->artisan('ds:init')
-        ->expectsQuestion('The file <comment>laradumps.php</comment> already exists. Delete it?', true)
+        ->expectsQuestion('The config file <comment>laradumps.php</comment> already exists. Delete it?', true)
         ->expectsQuestion('Select the App host address', 'other')
         ->expectsQuestion('Enter the App Host', '5.7.9.11')
         ->expectsQuestion('Enter the App Port', '5555')

--- a/tests/InitCommandTest.php
+++ b/tests/InitCommandTest.php
@@ -15,19 +15,20 @@ it('publishes the config file', function () {
 });
 
 it('updates the config non-interactively', function () {
-    $this->artisan('ds:init --no-interaction --host=1.2.3.4 --port=2022 --send_queries=true --send_logs=true --livewire_validation=true --livewire_autoclear=true --send_livewire=true --auto_invoke=true --ide=atom');
+    $this->artisan('ds:init --no-interaction --host=1.2.3.4 --port=2022 --send_queries=true --send_logs=true --livewire_events=true --livewire_validation=true --livewire_autoclear=true --send_livewire=true --auto_invoke=true --ide=atom');
 
     expect(config('laradumps.host'))->toBe('1.2.3.4');
     expect(config('laradumps.port'))->toBe('2022');
     expect(config('laradumps.send_queries'))->toBeTrue();
     expect(config('laradumps.send_log_applications'))->toBeTrue();
     expect(config('laradumps.send_livewire_components'))->toBeTrue();
+    expect(config('laradumps.send_livewire_events'))->toBeTrue();
     expect(config('laradumps.send_livewire_failed_validation.enabled'))->toBeTrue();
     expect(config('laradumps.auto_clear_on_page_reload'))->toBeTrue();
     expect(config('laradumps.auto_invoke_app'))->toBeTrue();
     expect(config('laradumps.preferred_ide'))->toBe('atom');
 
-    $this->artisan('ds:init --no-interaction --host=5.6.7.8 --port=2023 --send_queries=false --send_logs=false --send_livewire=false  --livewire_validation=false --livewire_autoclear=false --auto_invoke=false  --ide=vscode');
+    $this->artisan('ds:init --no-interaction --host=5.6.7.8 --port=2023 --send_queries=false --send_logs=false --send_livewire=false --livewire_events=false  --livewire_validation=false --livewire_autoclear=false --auto_invoke=false  --ide=vscode');
     $this->artisan('config:clear');
 
     expect(config('laradumps.host'))->toBe('5.6.7.8');
@@ -35,6 +36,7 @@ it('updates the config non-interactively', function () {
     expect(config('laradumps.send_queries'))->toBeFalse();
     expect(config('laradumps.send_log_applications'))->toBeFalse();
     expect(config('laradumps.send_livewire_components'))->toBeFalse();
+    expect(config('laradumps.send_livewire_events'))->toBeFalse();
     expect(config('laradumps.send_livewire_failed_validation.enabled'))->toBeFalse();
     expect(config('laradumps.auto_clear_on_page_reload'))->toBeFalse();
     expect(config('laradumps.auto_invoke_app'))->toBeFalse();
@@ -49,6 +51,7 @@ it('updates the config through the wizard', function () {
         ->expectsQuestion('Allow dumping <comment>SQL Queries</comment> to the App?', true)
         ->expectsQuestion('Allow dumping <comment>Laravel Logs</comment> to the App?', false)
         ->expectsQuestion('Allow dumping <comment>Livewire components</comment> to the App?', true)
+        ->expectsQuestion('Allow dumping <comment>Livewire Events</comment> to the App?', true)
         ->expectsQuestion('Allow dumping <comment>Livewire failed validation</comment> to the App?', true)
         ->expectsQuestion('Enable <comment>Auto-clear</comment> APP History on page reload?', true)
         ->expectsQuestion('Would you like to invoke the App window on every Dump?', true)
@@ -72,6 +75,7 @@ it('updates the config through the wizard', function () {
         ->expectsQuestion('Allow dumping <comment>SQL Queries</comment> to the App?', false)
         ->expectsQuestion('Allow dumping <comment>Laravel Logs</comment> to the App?', true)
         ->expectsQuestion('Allow dumping <comment>Livewire components</comment> to the App?', false)
+        ->expectsQuestion('Allow dumping <comment>Livewire Events</comment> to the App?', false)
         ->expectsQuestion('Allow dumping <comment>Livewire failed validation</comment> to the App?', false)
         ->expectsQuestion('Enable <comment>Auto-clear</comment> APP History on page reload?', false)
         ->expectsQuestion('Would you like to invoke the App window on every Dump?', false)


### PR DESCRIPTION
Hi Luan,

This PR has no breaking changes, and it introduces small improvements:

`  ➕ `  Added the question for `DS_LIVEWIRE_EVENTS` in accordance to PR https://github.com/laradumps/laradumps/pull/39

---


### 1) The user will be prompted to delete the config file in case it has been previously published.

<img width="667" alt="CleanShot 2022-08-09 at 01 54 27@2x" src="https://user-images.githubusercontent.com/79267265/183588707-fbfbccea-7227-4fab-b345-1934b0c0de09.png">

---

### 2) The IDE List comes from the package config file instead of the published config file. This ensures that the user will always see the latest version.

<img width="902" alt="CleanShot 2022-08-09 at 09 34 50@2x" src="https://user-images.githubusercontent.com/79267265/183591547-0c0694a9-a549-4aab-877d-b900cd3e313e.png">

_When choosing "vscode_remote", the user will be informed that extra configuration is needed._

---

Please let me know if changes are required.

Greetings and thanks,

Dan