### PR TITLE
Adds Windows and macOS to GitHub Actions 

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,9 +12,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
         php: [ 8.1, 8.0 ]
         laravel: [ 9.*, ^8.75 ]
         dependency-version: [ prefer-stable ]
@@ -24,8 +25,7 @@ jobs:
           - laravel: ^8.75
             testbench: 6.*
 
-    name: PHP:${{ matrix.php }} / L:${{ matrix.laravel }}(${{ matrix.dependency-version }})
-
+    name: "PHP: ${{ matrix.php }} /  ${{ matrix.os }} / Lrvl: ${{ matrix.laravel }} (${{ matrix.dependency-version }})"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           tools: composer:v2
           coverage: none
 

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -86,5 +86,6 @@ $finder = Finder::create()
 return (new Config())
     ->setFinder($finder)
     ->setRules($rules)
+    ->setLineEnding(PHP_EOL)
     ->setRiskyAllowed(false)
     ->setUsingCache(true);


### PR DESCRIPTION
Hi Luan,

This PR adds Windows and MacOS to GitHub Actions and does not introduce breaking changes.

Users might be developing Laravel applications from Linux, macOS and Windows operating systems, so I believe it is beneficial to test the package in each of them.

<p align="center">
  <img width="308" alt="CleanShot 2022-08-09 at 22 02 35@2x" src="https://user-images.githubusercontent.com/79267265/183751143-4ae75964-e835-4b31-9dfa-e645033f286b.png">
</p>

Greetings and thanks,

Dan


