### PR TITLE
Feature: Time Tracker

### DIFF
--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -18,6 +18,7 @@ use LaraDumps\LaraDumps\Payloads\{ClearPayload,
     RoutesPayload,
     ScreenPayload,
     TablePayload,
+    TimeTrackPayload,
     ValidateStringPayload};
 
 class LaraDumps
@@ -252,5 +253,27 @@ class LaraDumps
         $this->send($payload);
 
         return $this;
+    }
+
+    /**
+     * Starts clocking a code block execution time
+     *
+     * @param string $reference Unique name for this time clocking
+     */
+    public function time(string $reference): void
+    {
+        $payload = new TimeTrackPayload($reference);
+        $this->send($payload);
+    }
+
+    /**
+     * Stops clocking a code block execution time
+     *
+     * @param string $reference Unique name called on ds()->time()
+     */
+    public function stopTime(string $reference): void
+    {
+        $payload = new TimeTrackPayload($reference);
+        $this->send($payload);
     }
 }

--- a/src/Payloads/Payload.php
+++ b/src/Payloads/Payload.php
@@ -19,6 +19,7 @@ abstract class Payload
         'events',
         'diff',
         'model',
+        'time-track',
     ];
 
     private ?bool $autoInvokeApp = null;

--- a/src/Payloads/TimeTrackPayload.php
+++ b/src/Payloads/TimeTrackPayload.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Payloads;
+
+class TimeTrackPayload extends Payload
+{
+    /**
+     * Clock script executiontime
+     *
+     * @param string $reference Reference name used in each call
+     */
+    public function __construct(
+        public string $reference
+    ) {
+    }
+
+    public function type(): string
+    {
+        return 'time-track';
+    }
+
+    /** @return array<string, mixed> */
+    public function content(): array
+    {
+        return [
+            'timeTrackerId' => base64_encode(config('app.name') . strtolower($this->reference)),
+            'label'         => $this->reference,
+            'time'          => microtime(true),
+        ];
+    }
+}


### PR DESCRIPTION
Hi Luan,

This PR introduces the feature `ds()->time()` which allows the user to wrap a piece of code and clock the execution time.
It is paired with the PR https://github.com/laradumps/app/pull/62.

### Motivation

Developers often make use of the `microtime()` approach to simply clock the execution time of a particular block of code.

Even though there are (better) alternatives to this approach, I believe having it as a method adds a convenient way, and a shortcut, for those who end up writing the entire code and passing to a `ds()` call.
 
### Usage


The user must wrap a piece of code with `ds()->time($reference)` and `ds()->stopTime($reference)`. 

The `$reference` must be a unique identifier and be the same, both in `time()` and `stopTime()`. This string can be a simple word or a short phrase, and it will also be used as the `label` for the result dump.

```php 
ds()->time('Large count');

for($i=0; $i<100000; $i++){
    //some code
}

ds()->stopTime('Large count');
```

Wrong usage:

```php
ds()->time('starts here');
//some code
ds()->stopTime('ends here'); //❌
```
## Examples 

<div align="center">
  <p align="center">
  <img width="779" alt="PR" src="https://user-images.githubusercontent.com/79267265/184387680-e2347832-c8a8-416f-abc2-63c8a66b01a0.png">
</p>
</div>

Even though the results are unlikely to be large, I thought of adding a human friendly format for new developers who are not used to milliseconds.

<div align="center">
  <p align="center">
<img src="https://user-images.githubusercontent.com/79267265/184395985-4514c6e4-a00d-4455-b3a1-96be2266aba3.png" width="400" height="400" />
</p>
</div>
---

Please let me know if there are any changes required.

Greetings and thanks

Dan
