### PR TITLE
[1.2] Enhancement URL in ds:init + bug fix

### DIFF
--- a/src/Actions/ConsoleUrl.php
+++ b/src/Actions/ConsoleUrl.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Actions;
+
+use Exception;
+
+final class ConsoleUrl
+{
+    /**
+     * Open a given URL from console
+     *
+     * @param string $url
+     * @return void
+     */
+    public static function open(string $url): void
+    {
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            throw new Exception('Invalid URL');
+        }
+
+        switch (PHP_OS_FAMILY) {
+            case 'Darwin':
+                $command = 'open';
+
+                break;
+            case 'Windows':
+                $command = 'start';
+
+                break;
+            case 'Linux':
+                $command = 'xdg-open';
+
+                break;
+            default:
+                return;
+        }
+
+        exec($command . ' ' . $url);
+    }
+}

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -119,6 +119,8 @@ class InitCommand extends Command
             }
 
             //Add blank space to avoid auto-completing suggestion
+            $defaultHost = (string) array_search($defaultHost, $hosts);
+
             $hosts = array_map(fn ($host) => ' ' . $host, $hosts);
 
             $host =  $this->choice(
@@ -132,7 +134,7 @@ class InitCommand extends Command
             }
 
             if ($host == 'other') {
-                $host = $this->ask('Enter the App Host', $defaultHost);
+                $host = $this->ask('Enter the App Host');
             }
 
             if ($host == 'host.docker.internal' && PHP_OS_FAMILY ==  'Linux') {

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -217,13 +217,16 @@ class InitCommand extends Command
         $sendLivewireEvents =  $this->option('livewire_events');
 
         if (empty($sendLivewireEvents) && $this->isInteractive) {
-            $sendLivewireEvents = $this->confirm('Allow dumping <comment>Livewire Events</comment> to the App?', true);
+            $sendLivewireEvents = $this->confirm('Allow dumping <comment>Livewire Events</comment> & <comment>Browser Events (dispatch)</comment> to the App?', true);
         }
 
         $sendLivewireEvents = filter_var($sendLivewireEvents, FILTER_VALIDATE_BOOLEAN);
 
         config()->set('laradumps.send_livewire_events', boolval($sendLivewireEvents));
         $this->updateEnv('DS_LIVEWIRE_EVENTS', ($sendLivewireEvents ? 'true' : 'false'));
+
+        config()->set('laradumps.send_livewire_dispatch', boolval($sendLivewireEvents));
+        $this->updateEnv('DS_LIVEWIRE_DISPATCH', ($sendLivewireEvents ? 'true' : 'false'));
 
         return $this;
     }

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -5,6 +5,7 @@ namespace LaraDumps\LaraDumps\Commands;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\{Artisan, File};
+use LaraDumps\LaraDumps\Actions\ConsoleUrl;
 use LaraDumps\LaraDumps\Commands\Concerns\{RenderAscii, UpdateEnv};
 
 class InitCommand extends Command
@@ -125,8 +126,12 @@ class InitCommand extends Command
                 $host = $this->ask('Enter the App Host', $defaultHost);
             }
 
-            if ($host ==  'host.docker.internal' && PHP_OS_FAMILY ==  'Linux') {
-                $this->line("\n❗<error>  IMPORTANT  </error>❗ You need to perform some extra configuration for Docker in Linux host. Read more at: http://laradumps.dev/#/laravel/get-started/configuration?id=host\n");
+            if ($host == 'host.docker.internal' && PHP_OS_FAMILY ==  'Linux') {
+                $docUrl = 'http://laradumps.dev/#/laravel/get-started/configuration?id=host';
+
+                if ($this->confirm("\n❗<error>  IMPORTANT  </error>❗ You need to perform some extra configuration for Docker with Linux host. Read more at: <comment>{$docUrl}</comment>.\n\nBrowse the documentation now?") === true) {
+                    ConsoleUrl::open($docUrl);
+                }
             }
         }
 
@@ -294,8 +299,12 @@ class InitCommand extends Command
             throw new Exception('Invalid IDE');
         }
 
-        if ($ide == 'vscode_remote') {
-            $this->line("\n❗<error>  IMPORTANT  </error>❗ You need to perform some extra configuration for VS Code Remote to work properly. Read more at: <comment>https://laradumps.dev/#/laravel/get-started/configuration?id=remote-vscode-wsl2</comment>\n");
+        if ($ide == 'vscode_remote' && $this->isInteractive) {
+            $docUrl = 'https://laradumps.dev/#/laravel/get-started/configuration?id=remote-vscode-wsl2';
+
+            if ($this->confirm("\n❗<error>  IMPORTANT  </error>❗ You need to perform some extra configuration for VS Code Remote to work properly. Read more at: <comment>{$docUrl}</comment>.\n\nBrowse the documentation now?") === true) {
+                ConsoleUrl::open($docUrl);
+            }
         }
 
         config()->set('laradumps.preferred_ide', $ide);

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -99,6 +99,13 @@ class InitCommand extends Command
         $host = $this->option('host');
 
         if (empty($host) && $this->isInteractive) {
+            $hosts =  [
+                '127.0.0.1',
+                'host.docker.internal',
+                '10.211.55.2',
+                'other',
+            ];
+
             $defaultHost = '127.0.0.1';
 
             //Homestead
@@ -111,16 +118,18 @@ class InitCommand extends Command
                 $defaultHost = 'host.docker.internal';
             }
 
-            $host = $this->choice(
+            //Add blank space to avoid auto-completing suggestion
+            $hosts = array_map(fn ($host) => ' ' . $host, $hosts);
+
+            $host =  $this->choice(
                 'Select the App host address',
-                [
-                    '127.0.0.1',
-                    'host.docker.internal',
-                    '10.211.55.2',
-                    'other',
-                ],
+                $hosts,
                 $defaultHost
             );
+
+            if (is_string($host)) {
+                $host = ltrim($host);
+            }
 
             if ($host == 'other') {
                 $host = $this->ask('Enter the App Host', $defaultHost);

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -296,24 +296,24 @@ class InitCommand extends Command
 
         $ideList = $this->ideConfigList();
 
-        if (empty($ide) && $this->isInteractive) {
+        if ($this->isInteractive && empty($ide)) {
             $ide = $this->choice(
                 'What is your preferred IDE for this project?',
                 $ideList,
                 'phpstorm'
             );
+
+            if ($ide == 'vscode_remote') {
+                $docUrl = 'https://laradumps.dev/#/laravel/get-started/configuration?id=remote-vscode-wsl2';
+
+                if ($this->confirm("\n❗<error>  IMPORTANT  </error>❗ You need to perform some extra configuration for VS Code Remote to work properly. Read more at: <comment>{$docUrl}</comment>.\n\nBrowse the documentation now?") === true) {
+                    ConsoleUrl::open($docUrl);
+                }
+            }
         }
 
         if (!in_array($ide, $ideList)) {
             throw new Exception('Invalid IDE');
-        }
-
-        if ($ide == 'vscode_remote' && $this->isInteractive) {
-            $docUrl = 'https://laradumps.dev/#/laravel/get-started/configuration?id=remote-vscode-wsl2';
-
-            if ($this->confirm("\n❗<error>  IMPORTANT  </error>❗ You need to perform some extra configuration for VS Code Remote to work properly. Read more at: <comment>{$docUrl}</comment>.\n\nBrowse the documentation now?") === true) {
-                ConsoleUrl::open($docUrl);
-            }
         }
 
         config()->set('laradumps.preferred_ide', $ide);

--- a/tests/InitCommandTest.php
+++ b/tests/InitCommandTest.php
@@ -23,6 +23,7 @@ it('updates the config non-interactively', function () {
     expect(config('laradumps.send_log_applications'))->toBeTrue();
     expect(config('laradumps.send_livewire_components'))->toBeTrue();
     expect(config('laradumps.send_livewire_events'))->toBeTrue();
+    expect(config('laradumps.send_livewire_dispatch'))->toBeTrue();
     expect(config('laradumps.send_livewire_failed_validation.enabled'))->toBeTrue();
     expect(config('laradumps.auto_clear_on_page_reload'))->toBeTrue();
     expect(config('laradumps.auto_invoke_app'))->toBeTrue();
@@ -37,6 +38,7 @@ it('updates the config non-interactively', function () {
     expect(config('laradumps.send_log_applications'))->toBeFalse();
     expect(config('laradumps.send_livewire_components'))->toBeFalse();
     expect(config('laradumps.send_livewire_events'))->toBeFalse();
+    expect(config('laradumps.send_livewire_dispatch'))->toBeFalse();
     expect(config('laradumps.send_livewire_failed_validation.enabled'))->toBeFalse();
     expect(config('laradumps.auto_clear_on_page_reload'))->toBeFalse();
     expect(config('laradumps.auto_invoke_app'))->toBeFalse();
@@ -51,7 +53,7 @@ it('updates the config through the wizard', function () {
         ->expectsQuestion('Allow dumping <comment>SQL Queries</comment> to the App?', true)
         ->expectsQuestion('Allow dumping <comment>Laravel Logs</comment> to the App?', false)
         ->expectsQuestion('Allow dumping <comment>Livewire components</comment> to the App?', true)
-        ->expectsQuestion('Allow dumping <comment>Livewire Events</comment> to the App?', true)
+        ->expectsQuestion('Allow dumping <comment>Livewire Events</comment> & <comment>Browser Events (dispatch)</comment> to the App?', true)
         ->expectsQuestion('Allow dumping <comment>Livewire failed validation</comment> to the App?', true)
         ->expectsQuestion('Enable <comment>Auto-clear</comment> APP History on page reload?', true)
         ->expectsQuestion('Would you like to invoke the App window on every Dump?', true)
@@ -75,7 +77,7 @@ it('updates the config through the wizard', function () {
         ->expectsQuestion('Allow dumping <comment>SQL Queries</comment> to the App?', false)
         ->expectsQuestion('Allow dumping <comment>Laravel Logs</comment> to the App?', true)
         ->expectsQuestion('Allow dumping <comment>Livewire components</comment> to the App?', false)
-        ->expectsQuestion('Allow dumping <comment>Livewire Events</comment> to the App?', false)
+        ->expectsQuestion('Allow dumping <comment>Livewire Events</comment> & <comment>Browser Events (dispatch)</comment> to the App?', false)
         ->expectsQuestion('Allow dumping <comment>Livewire failed validation</comment> to the App?', false)
         ->expectsQuestion('Enable <comment>Auto-clear</comment> APP History on page reload?', false)
         ->expectsQuestion('Would you like to invoke the App window on every Dump?', false)


### PR DESCRIPTION
Hi Luan,

This PR includes an enhancement to `artisan ds:init()` command, small improvements and a bug fix. 

## Browse Doc

Currently, we have two key points that require the user to read the documents to properly configure LaraDumps: `docker + linux` and `vscode remote`.

Now, whenever these options are selected, the user will be prompted to browse the documentation (`default: no`). This question improves the odds of users seeing this alert instead be carried with the output flow and thus be frustrated because things don't work.

<img width="945" alt="URL" src="https://user-images.githubusercontent.com/79267265/184527950-1af6ed52-4369-4320-a3ee-ce4d192e574a.png">

## Livewire Events & Browser Events

The question `Allow dumping Livewire Events & Browser Events (dispatch) to the App?` will now enable/disable both event functionalities.

## Host Auto-complete Bug

In the video [Como contribuir em projetos open source PHP ou Laravel? ](https://www.youtube.com/watch?v=8KsHhQ6GcBg) @icarojobs experienced an undesired auto-completion to "127.0.0.1" when trying to type "1" for docker host option.

I have appended a blank space to each option in order to avoid auto-completing. It might be strange to see a blank space on the default value `Select the App host address [ 127.0.0.1]:` but the wizard flow is not affected.
 
### Before

![bug jobs 1](https://user-images.githubusercontent.com/79267265/184527902-b654ca95-c300-4798-b167-5a70bd5ba8df.gif)

### After

![CleanShot 2022-08-14 at 10 15 22](https://user-images.githubusercontent.com/79267265/184528451-2196cbbc-58e7-459b-b043-b0d0aca14104.gif)


Please let me know if there are any changes required!

Greeting and thanks,

Dan

