### PR TITLE
Refactored HTTP into Action to remove dependency

### DIFF
--- a/src/Actions/SendPayload.php
+++ b/src/Actions/SendPayload.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Actions;
+
+use LaraDumps\LaraDumps\Exceptions\CannotSendPayloadException;
+use LaraDumps\LaraDumps\Payloads\Payload;
+
+final class SendPayload
+{
+    /**
+     * Sends Payload to the Desktop App
+     *
+     * @throws CannotSendPayloadException
+     */
+    public static function handle(string $appUrl, array|Payload $payload): string
+    {
+        $curlRequest = curl_init();
+
+        curl_setopt_array($curlRequest, [
+            CURLOPT_POST           => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_HTTPHEADER     => ['Content-Type: application/json', 'Accept: application/json'],
+            CURLOPT_POSTFIELDS     => json_encode($payload),
+            CURLOPT_URL            => $appUrl,
+        ]);
+
+        curl_close($curlRequest);
+
+        $curlResult = curl_exec($curlRequest);
+
+        if ($curlResult === false) {
+            return 'Could not connect to LaraDumps app. Is it closed?';
+
+            // CannotSendPayloadException::throw(curl_error($curlRequest));
+        }
+
+        return strval($curlResult);
+    }
+}

--- a/src/Exceptions/CannotSendPayloadException.php
+++ b/src/Exceptions/CannotSendPayloadException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Exceptions;
+
+use Exception;
+
+final class CannotSendPayloadException extends Exception
+{
+    /**
+     * @throws CannotSendPayloadException
+     */
+    public static function throw(string $message = ''): void
+    {
+        throw new static('LaraDumps: Could not send payload to app. ' . $message);
+    }
+}

--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -3,8 +3,8 @@
 namespace LaraDumps\LaraDumps;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\{Collection, Str};
+use LaraDumps\LaraDumps\Actions\SendPayload;
 use LaraDumps\LaraDumps\Concerns\Colors;
 use LaraDumps\LaraDumps\Observers\QueryObserver;
 use LaraDumps\LaraDumps\Payloads\{ClearPayload,
@@ -46,10 +46,7 @@ class LaraDumps
             $payload->notificationId($this->notificationId);
             $payload = $payload->toArray();
 
-            try {
-                Http::post($this->fullUrl, $payload);
-            } catch (\Throwable) {
-            }
+            SendPayload::handle($this->fullUrl, $payload);
         }
 
         return $payload;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace LaraDumps\LaraDumps\Tests;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\File;
+use LaraDumps\LaraDumps\Actions\SendPayload;
 use LaraDumps\LaraDumps\LaraDumpsServiceProvider;
 use LaraDumps\LaraDumps\Tests\Actions\TestDatabase;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -19,6 +20,16 @@ class TestCase extends BaseTestCase
         $this->clearViewsCache();
 
         TestDatabase::up();
+
+        $sendPayload = \Mockery::mock('overload:' . SendPayload::class);
+
+        $sendPayload->shouldReceive('handle')
+                ->andReturn(md5(uniqid(rand(), true)));
+    }
+
+    protected function tearDown(): void
+    {
+        \Mockery::close();
     }
 
     /**


### PR DESCRIPTION
# 🛻 LaraDumps Pull Request

<br/><table><tr><td>❗ You <b>MUST</b> use this template to submit a Pull Request or it will NOT be accepted. ❗</td></tr></table><br/>

Welcome and thank you for your interest in contributing to our project.

## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

### Related Issue(s)

### Description

While installing LaraDumps to debug the development of a Laravel Package, I noticed the following error:

<img width="467" alt="CleanShot 2022-10-01 at 13 37 13@2x" src="https://user-images.githubusercontent.com/79267265/193407689-ef824338-9f3f-4538-b01a-a62dc5db34f8.png">

My Laravel package does not have Guzzle installed.

One alternative would be to require `guzzlehttp/guzzle` with LaraDumps or even with the package-dev, but I questioned myself if it makes sense to add a dependency to only make a single post request. 

Guzzle depends on `ext-curl` so I took the approach of simplifying and refactored the `Http` call into an action using curl directly.

I could not see any security risk since we are dealing we local requests and do not make use of `Authorization`.

### Contribution Guide

- [X] I have read and followed the steps listed in the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
