### PR TITLE
[Fix] Update CI Deprecations

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         php: [ 8.1, 8.0 ]
         laravel: [ 9.*, ^8.75 ]
         dependency-version: [ prefer-stable ]
@@ -28,7 +28,7 @@ jobs:
     name: "PHP: ${{ matrix.php }} /  ${{ matrix.os }} / Lrvl: ${{ matrix.laravel }} (${{ matrix.dependency-version }})"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Setup PHP, with composer and extensions
         uses: shivammathur/setup-php@v2
@@ -38,14 +38,10 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
       - name: Cache composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: $(composer config cache-files-dir)
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
           restore-keys: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,5 +10,3 @@ parameters:
     checkGenericClassInNonGenericObjectType: false
 
     ignoreErrors:
-        - '#Call to an undefined static method .*Str::cut\(\)#'
-        - '#Parameter \#1 \$view of function view expects view-string\|null, string given\.#'


### PR DESCRIPTION
# 🛻 LaraDumps Pull Request

Welcome and thank you for your interest in contributing to our project.

## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

### Description

This Pull Request is a work in progress, and fix deprecated GitHub actions seen in Annotations on this [run](https://github.com/laradumps/laradumps/actions/runs/3259434554).

#### `   👨‍🏭 `  To Fix

- [ ] The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

- [X] Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/cache, actions/cache, actions/checkout

- [X] The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

- [X] macOS-latest pipelines will use macOS-12 soon. For more details, see https://github.com/actions/runner-images/issues/6384

I am not certain why we still have the annotation `The 'set-output' command is deprecated and will be disabled soon.` since `echo "::set-output` calls were removed.

### Contribution Guide

- [X] I have read and followed the steps listed in the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
