### PR TITLE
ds:check --dirty

### DIFF
--- a/src/Actions/GitDirtyFiles.php
+++ b/src/Actions/GitDirtyFiles.php
@@ -12,7 +12,7 @@ final class GitDirtyFiles
      * Code snippet taken from laravel/pint
      * url: https://github.com/laravel/pint/pull/130
      */
-    public static function run()
+    public static function run(): array
     {
         $process = tap(new Process(['git', 'status', '--short', '--', '*.php']))->run();
 
@@ -20,8 +20,8 @@ final class GitDirtyFiles
             abort(1);
         }
 
-        return collect(preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY))
-            ->mapWithKeys(fn ($file) => [substr($file, 3) => trim(substr($file, 0, 3))])
+        return collect((array) preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY))
+            ->mapWithKeys(fn ($file) => [substr(strval($file), 3) => trim(substr(strval($file), 0, 3))])
             ->reject(fn ($status) => $status === 'D')
             ->map(fn ($status, $file) => $status === 'R' ? Str::after($file, ' -> ') : $file)
             ->map(fn ($file) => getcwd() . '/' . $file)

--- a/src/Actions/GitDirtyFiles.php
+++ b/src/Actions/GitDirtyFiles.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Actions;
+
+use Illuminate\Support\Str;
+use Symfony\Component\Process\Process;
+
+/**
+ * Code snippet taken from laravel/pint
+ * https://github.com/laravel/pint/pull/130
+ */
+class GitDirtyFiles
+{
+    public static function run()
+    {
+        $process = tap(new Process(['git', 'status', '--short', '--', '*.php']))->run();
+
+        if (!$process->isSuccessful()) {
+            abort(1);
+        }
+
+        return collect(preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY))
+            ->mapWithKeys(fn ($file) => [substr($file, 3) => trim(substr($file, 0, 3))])
+            ->reject(fn ($status) => $status === 'D')
+            ->map(fn ($status, $file) => $status === 'R' ? Str::after($file, ' -> ') : $file)
+            ->map(fn ($file) => getcwd() . '/' . $file)
+            ->values()
+            ->all();
+    }
+}

--- a/src/Actions/GitDirtyFiles.php
+++ b/src/Actions/GitDirtyFiles.php
@@ -5,12 +5,13 @@ namespace LaraDumps\LaraDumps\Actions;
 use Illuminate\Support\Str;
 use Symfony\Component\Process\Process;
 
-/**
- * Code snippet taken from laravel/pint
- * https://github.com/laravel/pint/pull/130
- */
-class GitDirtyFiles
+final class GitDirtyFiles
 {
+    /**
+     * @internal
+     * Code snippet taken from laravel/pint
+     * url: https://github.com/laravel/pint/pull/130
+     */
     public static function run()
     {
         $process = tap(new Process(['git', 'status', '--short', '--', '*.php']))->run();

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -3,6 +3,7 @@
 namespace LaraDumps\LaraDumps\Commands;
 
 use Illuminate\Console\Command;
+use LaraDumps\LaraDumps\Actions\GitDirtyFiles;
 use LaraDumps\LaraDumps\Support\IdeHandle;
 use Symfony\Component\Finder\Finder;
 
@@ -10,12 +11,18 @@ use function Termwind\{render, renderUsing};
 
 class CheckCommand extends Command
 {
-    protected $signature = 'ds:check';
+    protected $signature = 'ds:check {--dirty}';
 
     protected $description = 'Check if you forgot any ds() in your files';
 
     public function handle(): int
     {
+        $files = [];
+
+        if (!empty($this->option('dirty'))) {
+            $files = GitDirtyFiles::run();
+        }
+
         /** @var array<string>|string $directories */
         $directories = config('laradumps.ci_check.directories');
 
@@ -36,6 +43,10 @@ class CheckCommand extends Command
         $this->output->writeln('');
 
         foreach ($finder as $file) {
+            if (!in_array($file->getRealPath(), $files)) {
+                continue;
+            }
+
             $progressBar->advance();
 
             /** @var string[] $contents */

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -17,10 +17,10 @@ class CheckCommand extends Command
 
     public function handle(): int
     {
-        $files = [];
+        $dirtyFiles = [];
 
         if (!empty($this->option('dirty'))) {
-            $files = GitDirtyFiles::run();
+            $dirtyFiles = GitDirtyFiles::run();
         }
 
         /** @var array<string>|string $directories */
@@ -38,12 +38,12 @@ class CheckCommand extends Command
 
         $finder->files()->in($directories);
 
-        $progressBar = $this->output->createProgressBar(count($files) ?: $finder->count());
+        $progressBar = $this->output->createProgressBar(count($dirtyFiles) ?: $finder->count());
 
         $this->output->writeln('');
 
         foreach ($finder as $file) {
-            if (filled($files) && !in_array($file->getRealPath(), $files)) {
+            if (filled($dirtyFiles) && !in_array($file->getRealPath(), $dirtyFiles)) {
                 continue;
             }
 

--- a/src/Commands/CheckCommand.php
+++ b/src/Commands/CheckCommand.php
@@ -38,12 +38,12 @@ class CheckCommand extends Command
 
         $finder->files()->in($directories);
 
-        $progressBar = $this->output->createProgressBar($finder->count());
+        $progressBar = $this->output->createProgressBar(count($files) ?: $finder->count());
 
         $this->output->writeln('');
 
         foreach ($finder as $file) {
-            if (!in_array($file->getRealPath(), $files)) {
+            if (filled($files) && !in_array($file->getRealPath(), $files)) {
                 continue;
             }
 


### PR DESCRIPTION
# 🛻 LaraDumps Pull Request

Welcome and thank you for your interest in contributing to our project.

## Guidelines

`   🗒️ `  Please read the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`   ✍️ `  Give this PR a meaningful title.

`   📣 `  Describe your PR details below.

## Pull Request Information

### Motivation

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

### Related Issue(s)

This PR allows _ds:check_ to parse files that have not yet been committed to git when using `--dirty ` as a parameter.

**intended for use only in the commit-msg hook or for quick query**

```bash
php artisan ds:check --dirty
```

This code snippet was taken from laravel pint #https://github.com/laravel/pint/pull/130

### Contribution Guide

- [ ] I have read and followed the steps listed in the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [x] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
