### PR TITLE
[Pipeline] Checking for forgotten var dump functions

### DIFF
--- a/.github/workflows/check_vardump.yml
+++ b/.github/workflows/check_vardump.yml
@@ -1,0 +1,51 @@
+name: Var Dump Check
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+
+  pull_request:
+    types: [ ready_for_review, synchronize, opened ]
+    branches: [ main, dev ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Check for var dump (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php:
+          - '8.1'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          coverage: none
+          tools: cs2pr
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Install php-parallel-lint/php-var-dump-check
+        run: |
+          composer require "php-parallel-lint/php-var-dump-check" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+        
+      - name: 'Checking for var dump in code 🕵🏻'
+        run: |
+          ./vendor/bin/var-dump-check src/ --laravel --custom-function "$CUSTOM_FUNCTIONS"
+          ./vendor/bin/var-dump-check routes/ --laravel --custom-function "$CUSTOM_FUNCTIONS"
+        env:
+          CUSTOM_FUNCTIONS: "logger"


### PR DESCRIPTION
# 🛻 LaraDumps Pull Request

<br/><table><tr><td>❗ You <b>MUST</b> use this template to submit a Pull Request or it will NOT be accepted. ❗</td></tr></table><br/>

Welcome and thank you for your interest in contributing to our project.

## Guidelines

`  🗒️  `  Please read the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md) and follow all steps listed there.

`  ✍️  `  Give this PR a meaningful title.

`  📣  `  Describe your PR details below.

## Pull Request Information

### Motivation

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change

### Description

This Pull Request introduces a new GitHub action to check if there are any forgotten/left-over var dump functions.

After the fix in https://github.com/laradumps/laradumps/pull/84 removing residual `logger()` function, I have decided to reduce the possibility of this happening again.

This action uses the package `php-parallel-lint/PHP-Var-Dump-Check`, passing the `--laravel` flag.  This option searches for `dd()` and `dump()`. I have also added the flag `--custom-function` to search for `logger()`.

To search for other debug functions, we just need to append to the `CUSTOM_FUNCTIONS` env var, in a comma separated format:

```yml
      - name: 'Checking for var dump in code 🕵🏻'
        run: |
          ./vendor/bin/var-dump-check src/ --laravel --custom-function "$CUSTOM_FUNCTIONS"
          ./vendor/bin/var-dump-check routes/ --laravel --custom-function "$CUSTOM_FUNCTIONS"
        env:
          CUSTOM_FUNCTIONS: "logger,some_function,anotherFunction"
```

Currently, the action iss searching the folders `/src` and `/routes`.

### Contribution Guide

- [X] I have read and followed the steps listed in the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.
