### PR TITLE
Update QueryObserver.php

### DIFF
--- a/src/Observers/QueryObserver.php
+++ b/src/Observers/QueryObserver.php
@@ -26,7 +26,7 @@ class QueryObserver implements TraceableContract
                 return;
             }
 
-            $sqlQuery = str_replace(['?'], ['\'%s\''], $query->sql);
+            $sqlQuery = str_replace(['%', '?'], ['%%', '\'%s\''], $query->sql);
             $sqlQuery = vsprintf($sqlQuery, $query->bindings);
 
             if (str_contains($sqlQuery, 'telescope')) {


### PR DESCRIPTION
# 🛻 LaraDumps Pull Request

## Pull Request Information

### Motivation

- [✓] Bug fix
- [ ] New feature
- [ ] Breaking change

### Description

This Pull Request fixes the exception below: "Unknown format specifier..."

![stacktrace](https://user-images.githubusercontent.com/12158575/231575364-4c5c32c1-dd5c-430f-b0b2-471d6121a89a.png)

Example query: "SELECT DATE_FORMAT(NOW(), '%Y-%m-%d') AS today FROM ..." would throw this exception.
This happened due to vsprintf function interpreting '%m' as if it was a formatter string. 
https://www.php.net/manual/en/function.vsprintf.php


### Contribution Guide

- [✓ ] I have read and followed the steps listed in the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [✓ ] No
- [ ] I have already submitted a Documentation pull request.
