### PR TITLE
Fix the require './functions' which broke on PHP 8.2 Win

### DIFF
--- a/src/LaraDumpsServiceProvider.php
+++ b/src/LaraDumpsServiceProvider.php
@@ -47,7 +47,7 @@ class LaraDumpsServiceProvider extends ServiceProvider
             'laradumps'
         );
 
-        $file = __DIR__ . './functions.php';
+        $file = __DIR__ . DIRECTORY_SEPARATOR . 'functions.php';
         if (file_exists($file)) {
             require_once($file);
         }


### PR DESCRIPTION
Hello,

I noticed a "permission denied" when trying to require the functions file on PHP 8.2 Windows, where there was no issues with PHP 8.1