### PR TITLE
check dirty only on stashed changes

### DIFF
--- a/src/Actions/GitDirtyFiles.php
+++ b/src/Actions/GitDirtyFiles.php
@@ -21,7 +21,9 @@ final class GitDirtyFiles
         }
 
         return collect((array) preg_split('/\R+/', $process->getOutput(), flags: PREG_SPLIT_NO_EMPTY))
-            ->mapWithKeys(fn ($file) => [substr(strval($file), 3) => trim(substr(strval($file), 0, 3))])
+            ->mapWithKeys(fn ($file) => [substr(strval($file), 3) => substr(strval($file), 0, 3)])
+            ->reject(fn ($status) => !str_ends_with($status, '  '))
+            ->map(fn ($status) => trim($status))
             ->reject(fn ($status) => $status === 'D')
             ->map(fn ($status, $file) => $status === 'R' ? Str::after($file, ' -> ') : $file)
             ->map(fn ($file) => getcwd() . '/' . $file)


### PR DESCRIPTION
# 🛻 LaraDumps Pull Request
## Pull Request Information

### Motivation
- [x] Enhancement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

### Related Issue(s)

### Description
Often we are working with many files, so when I have the file A and B, but in the file B I have a dd or ds and in the file A i don't  and i want to make a commit just with the file A changes. The check dirt blocks my commit because of the file B. But the file A is correct and is the just one i want to make a commit.

This Pull Request adds a check constraint that will just consider the check dirty for the "staged changes files", checking only the files i want to use for that specific commit.

### Contribution Guide

- [ ] I have read and followed the steps listed in the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md).

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
