### PR TITLE
Always show the original dump in testing

### DIFF
--- a/src/Observers/DumpObserver.php
+++ b/src/Observers/DumpObserver.php
@@ -68,6 +68,10 @@ class DumpObserver
 
     public function displayOriginalDump(): bool
     {
+        if (runningInTest()) {
+            return true;
+        }
+
         return (bool) Config::get('observers.original_dump', true);
     }
 }


### PR DESCRIPTION
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

### Related Issue(s)

This PR Fixes the Issue #144 .

### Description

During the execution of the tests, laradumps is trying to check whether the key is in laradumps.yaml "running in tests" is enabled. However, the verification itself in Config::get() is always returned as false.

Let's enable the original dump in tests regardless of any configuration in Laradump

_Another alternative would be to remove the check in Config::get and move it. This can take a long time_

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
