### PR TITLE
Add Livewire debug attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "pestphp/pest": "^2.28.1",
         "laravel/pint": "^1.13.7",
         "larastan/larastan": "^2.7",
-        "mockery/mockery": "^1.6"
+        "mockery/mockery": "^1.6",
+        "livewire/livewire": "^3.4"
     },
     "autoload": {
         "psr-4": {

--- a/src/Livewire/Attributes/Ds.php
+++ b/src/Livewire/Attributes/Ds.php
@@ -9,7 +9,7 @@ use LaraDumps\LaraDumpsCore\Payloads\Payload;
 use Livewire\Component;
 use Livewire\Mechanisms\HandleComponents\ComponentContext;
 
-#[\Attribute]
+#[\Attribute(\Attribute::TARGET_CLASS)]
 class Ds extends \Livewire\Attribute
 {
     protected static array $profiles = [];

--- a/src/Livewire/Attributes/Ds.php
+++ b/src/Livewire/Attributes/Ds.php
@@ -17,10 +17,6 @@ class Ds extends \Livewire\Attribute
 
     public function boot(): void
     {
-        if (app()->isProduction()) {
-            return;
-        }
-
         DB::enableQueryLog();
 
         \Livewire\on('profile', function (string $method, string $livewireId, $measurement) {
@@ -83,10 +79,10 @@ class Ds extends \Livewire\Attribute
     private function matchClass(string $method): string
     {
         return match ($method) {
-            'mount'  => 'border-l-4 border-primary',
-            'render' => 'border-l-4 border-secondary',
-            'hydrate', 'dehydrate' => 'border-l-4 border-accent',
-            default => 'border-l-4 border-info'
+            'mount'  => 'border-primary',
+            'render' => 'border-secondary',
+            'hydrate', 'dehydrate' => 'border-accent',
+            default => 'border-l-4 border-neutral'
         };
     }
 }

--- a/src/Livewire/Attributes/Ds.php
+++ b/src/Livewire/Attributes/Ds.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Livewire\Attributes;
+
+use Illuminate\Support\Facades\DB;
+use LaraDumps\LaraDumpsCore\Actions\Dumper;
+use LaraDumps\LaraDumpsCore\LaraDumps;
+use LaraDumps\LaraDumpsCore\Payloads\Payload;
+use Livewire\Component;
+use Livewire\Mechanisms\HandleComponents\ComponentContext;
+
+#[\Attribute]
+class Ds extends \Livewire\Attribute
+{
+    protected static array $profiles = [];
+
+    public function boot(): void
+    {
+        if (app()->isProduction()) {
+            return;
+        }
+
+        DB::enableQueryLog();
+
+        \Livewire\on('profile', function (string $method, string $livewireId, $measurement) {
+            if ($livewireId != $this->getComponent()->getId()) {
+                return;
+            }
+
+            $startedAt = $measurement[0];
+            $endedAt   = $measurement[1];
+
+            static::$profiles[$livewireId][] = [
+                'classes'  => $this->matchClass($method),
+                'method'   => $method,
+                'duration' => $this->duration($startedAt, $endedAt),
+            ];
+        });
+
+        \Livewire\on('dehydrate', function (Component $component, ComponentContext $context) {
+            if ($component->getId() == $this->getComponent()->getId()) {
+                $properties = $context->component->all();
+                $errors     = $context->memo['errors'] ?? [];
+                $events     = $context->effects['dispatches'] ?? [];
+
+                $payload = [
+                    'queries'    => DB::getQueryLog(),
+                    'request'    => uniqid(),
+                    'id'         => $context->component->getId(),
+                    'name'       => $context->component->getName(),
+                    'profile'    => static::$profiles[$context->component->getId()],
+                    'properties' => Dumper::dump($properties),
+                    'errors'     => filled($errors) ? Dumper::dump($errors) : [],
+                    'events'     => $events,
+                ];
+
+                $payload = new LivewirePayload($payload);
+
+                $laradumps = app(LaraDumps::class);
+                $laradumps->send($payload);
+                $laradumps->toScreen('Livewire');
+
+                unset(static::$profiles[$context->component->getId()]);
+
+                DB::disableQueryLog();
+            }
+        });
+    }
+
+    private function duration(float $startTime, float $endTime): float
+    {
+        return round((($endTime - $startTime) * 1000));
+    }
+
+    private function matchClass(string $method): string
+    {
+        return match ($method) {
+            'mount'  => 'border-l-4 border-primary',
+            'render' => 'border-l-4 border-secondary',
+            'hydrate', 'dehydrate' => 'border-l-4 border-accent',
+            default => 'border-l-4 border-info'
+        };
+    }
+}
+
+class LivewirePayload extends Payload
+{
+    public function __construct(
+        public array $payload
+    ) {
+    }
+
+    public function type(): string
+    {
+        return 'livewire';
+    }
+
+    public function content(): array
+    {
+        return $this->payload;
+    }
+}

--- a/src/Livewire/Attributes/Ds.php
+++ b/src/Livewire/Attributes/Ds.php
@@ -3,6 +3,7 @@
 namespace LaraDumps\LaraDumps\Livewire\Attributes;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Number;
 use LaraDumps\LaraDumpsCore\Actions\Dumper;
 use LaraDumps\LaraDumpsCore\LaraDumps;
 use LaraDumps\LaraDumpsCore\Payloads\Payload;
@@ -39,6 +40,12 @@ class Ds extends \Livewire\Attribute
 
         \Livewire\on('dehydrate', function (Component $component, ComponentContext $context) {
             if ($component->getId() == $this->getComponent()->getId()) {
+                $size = Number::fileSize(
+                    strlen(
+                        (string) json_encode([$component, $context])
+                    )
+                );
+
                 $properties = $context->component->all();
                 $errors     = $context->memo['errors'] ?? [];
                 $events     = $context->effects['dispatches'] ?? [];
@@ -52,6 +59,7 @@ class Ds extends \Livewire\Attribute
                     'properties' => Dumper::dump($properties),
                     'errors'     => filled($errors) ? Dumper::dump($errors) : [],
                     'events'     => $events,
+                    'size'       => $size,
                 ];
 
                 $payload = new LivewirePayload($payload);


### PR DESCRIPTION
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

### Description

Until the ["livewire wiretap"](https://www.youtube.com/watch?v=U-N8Qqq02b0&pp=ygUSbGFyYWNvbiAyMDIzIGNhbGVi) is released, LaraDumps will support debugging one component at a time.

* All requests for the component you placed will be sent to LaraDumps.
* This will only work if `app.debug` is enabled.
* The runtime information (profile) is sent via livewire using `trigger('profile')` and is **not processed by LaraDumps**.
* The "_KB_" information is an approximate. Does not work when the component has children

## Usage

```php
#[Ds]
class ValidationTable extends PowerGridComponent
{    
    // ...
}
```

---

### Profile

![image](https://github.com/laradumps/laradumps/assets/33601626/833d9b08-9214-4212-ab14-bb567a632282)

---

### Properties

![image](https://github.com/laradumps/laradumps/assets/33601626/0c18c27b-a968-4fa9-8f9a-4c569967ad8b)

---

### Queries

![image](https://github.com/laradumps/laradumps/assets/33601626/c5d7c00a-27fe-439a-b9e9-47bf67d34cf9)

---

### Validation

![image](https://github.com/laradumps/laradumps/assets/33601626/084b0cf6-2f97-442d-afe6-32605f4bd7af)

---

### Events

![image](https://github.com/laradumps/laradumps/assets/33601626/bf5e1b38-f70a-4dcb-9df3-ab41cf884647)

---

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [ ] No
- [ ] I have already submitted a Documentation pull request.
