### PR TITLE
[Feature] Add TestResponse macro and pestphp extends

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,20 +14,20 @@
     ],
     "require": {
         "php": "^8.1",
-        "nunomaduro/termwind": "^1.15.1|^2.0.0",
+        "nunomaduro/termwind": "^1.15.1|^2.0.1",
         "illuminate/support": "^10.0|^11.0",
         "illuminate/mail": "^10.0|^11.0",
-        "laradumps/laradumps-core": "^2.0"
+        "laradumps/laradumps-core": "^2.2"
     },
     "require-dev": {
-        "orchestra/testbench-core": "^8.0|^9.0",
-        "laravel/framework": "^10.0|^11.0",
-        "symfony/var-dumper": "^6.4.0|^7.0.3",
-        "pestphp/pest": "^2.28.1",
-        "laravel/pint": "^1.13.7",
-        "larastan/larastan": "^2.7",
-        "mockery/mockery": "^1.6",
-        "livewire/livewire": "^3.4"
+        "orchestra/testbench-core": "^8.0|^9.4",
+        "laravel/framework": "^10.0|^11.21",
+        "symfony/var-dumper": "^6.4.0|^7.1.3",
+        "pestphp/pest": "^2.35.1",
+        "laravel/pint": "^1.17.2",
+        "larastan/larastan": "^2.9.8",
+        "mockery/mockery": "^1.6.12",
+        "livewire/livewire": "^3.5.6"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,5 +4,6 @@ parameters:
     paths:
         - src
     level: max
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
+    ignoreErrors:
+        - identifier: missingType.iterableValue
+        - identifier: missingType.generics


### PR DESCRIPTION
Now, you can use LaraDumps in tests

* pestphp example
```php
expect(true)
  ->ds() // Send 'true' to Laradumps app
  ->toBeTrue();
```

* livewire example

```php
livewire($component)
  ->set('isOpen', true)
  ->ds() // Send headers and data component to Laradumps app
 // ...
```
