### PR TITLE
change DB::listen to Event::Listen to avoid wrong database connection

### DIFF
--- a/src/Observers/QueryObserver.php
+++ b/src/Observers/QueryObserver.php
@@ -3,7 +3,7 @@
 namespace LaraDumps\LaraDumps\Observers;
 
 use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\{DB, Event};
 use LaraDumps\LaraDumps\Payloads\QueriesPayload;
 use LaraDumps\LaraDumpsCore\Actions\Config;
 use LaraDumps\LaraDumpsCore\LaraDumps;
@@ -18,7 +18,7 @@ class QueryObserver
 
     public function register(): void
     {
-        DB::listen(function (QueryExecuted $query) {
+        Event::listen(QueryExecuted::class, function (QueryExecuted $query) {
             if (!$this->isEnabled()) {
                 return;
             }

--- a/src/Observers/SlowQueryObserver.php
+++ b/src/Observers/SlowQueryObserver.php
@@ -3,7 +3,7 @@
 namespace LaraDumps\LaraDumps\Observers;
 
 use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Support\Facades\{DB};
+use Illuminate\Support\Facades\{DB, Event};
 use LaraDumps\LaraDumps\Payloads\QueriesPayload;
 use LaraDumps\LaraDumpsCore\Actions\Config;
 use LaraDumps\LaraDumpsCore\LaraDumps;
@@ -12,7 +12,7 @@ class SlowQueryObserver
 {
     public function register(): void
     {
-        DB::listen(function (QueryExecuted $query) {
+        Event::listen(QueryExecuted::class, function (QueryExecuted $query) {
             if (!$this->isEnabled()) {
                 return;
             }


### PR DESCRIPTION
### Motivation

- [X] Bug fix

### Related Issue(s)

This PR Fixes the Issue #176 

### Description

This Pull Request changes DB::listen to DB::event to avoid having the wrong connection when you're changing connections on-the-fly (i.e. switching tenants)

### Documentation
- [X] No
