### PR TITLE
Implement query explain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,7 @@
         "verify": [
             "@test:pint",
             "@test:types",
-            "@test:tests",
-            "@test:types"
+            "@test:tests"
         ]
     },
     "extra": {

--- a/src/Commands/laradumps-base.yaml
+++ b/src/Commands/laradumps-base.yaml
@@ -28,3 +28,5 @@ slow_queries:
   threshold_in_ms: 500
 extra:
   context: false
+queries:
+  explain: false

--- a/src/Observers/QueryObserver.php
+++ b/src/Observers/QueryObserver.php
@@ -3,10 +3,13 @@
 namespace LaraDumps\LaraDumps\Observers;
 
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\{DB, Event};
 use LaraDumps\LaraDumps\Payloads\QueriesPayload;
+use LaraDumps\LaraDumpsCore\Actions\Config;
 use LaraDumps\LaraDumpsCore\LaraDumps;
-use Spatie\Backtrace\Backtrace;
+use Spatie\Backtrace\{Backtrace, Frame};
+use Throwable;
 
 class QueryObserver extends BaseObserver
 {
@@ -37,26 +40,41 @@ class QueryObserver extends BaseObserver
         try {
             $sql = DB::getQueryGrammar()->substituteBindingsIntoRawSql($query->sql, $query->bindings);
 
+            if ($this->isExplainQuery($query->sql)) {
+                return;
+            }
+
             $queries = $this->buildQueryPayload($query, $sql);
-            $frame = app(LaraDumps::class)->parseFrame(Backtrace::create());
 
             $payload = new QueriesPayload($queries);
-            $payload->setFrame($frame);
+            $payload->setFrame($this->parseFrame());
 
-            $dumper = new LaraDumps();
-            $dumper->send($payload, withFrame: false);
-
-            if ($this->label) {
-                $dumper->label($this->label);
-            }
-        } catch (\Throwable) {
+            $this->sendPayload($payload);
+        } catch (Throwable) {
         }
+    }
+
+    private function isExplainQuery(string $sql): bool
+    {
+        return str_starts_with(strtolower(ltrim($sql)), 'explain format=json');
+    }
+
+    private function parseFrame(): array|Frame
+    {
+        return app(LaraDumps::class)->parseFrame(Backtrace::create());
+    }
+
+    private function sendPayload(QueriesPayload $payload): void
+    {
+        $dumper = new LaraDumps();
+        $dumper->send($payload, withFrame: false);
+
+        $this->label && $dumper->label($this->label);
     }
 
     private function buildQueryPayload(QueryExecuted $query, string $sql): array
     {
         $request = $this->resolveRequestContext();
-
         $query->sql = $sql;
 
         return [
@@ -69,27 +87,118 @@ class QueryObserver extends BaseObserver
             'method' => $request['method'],
             'origin' => $request['origin'],
             'argv' => $request['argv'],
+            'explain_nodes' => $this->maybeExplainQuery($query->sql),
         ];
+    }
+
+    private function maybeExplainQuery(string $sql): array
+    {
+        if (! Config::get('queries.explain', false)) {
+            return [];
+        }
+
+        if (! str_starts_with(strtolower($sql), 'select')) {
+            return [];
+        }
+
+        return $this->extractExplain($sql);
+    }
+
+    public function extractExplain(string $originalQuery): array
+    {
+        try {
+            $result = DB::select('EXPLAIN FORMAT=JSON '.$originalQuery);
+            DB::connection()->enableQueryLog();
+
+            $jsonText = $result[0]->{'EXPLAIN'} ?? null;
+
+            if (! $jsonText) {
+                return [];
+            }
+
+            /** @var array $data */
+            $data = json_decode($jsonText, true);
+
+            $problematicNodes = [];
+            $this->analyzeJsonExplainNode($data['query_block'] ?? $data, $problematicNodes);
+
+            return $problematicNodes;
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    private function analyzeJsonExplainNode(array $node, array &$problematicNodes): void
+    {
+        $this->checkTableAccess($node, $problematicNodes);
+
+        foreach (['nested_loop', 'query_block', 'attached_condition', 'grouping_operation', 'table'] as $childKey) {
+            $this->processChildNode($node, $childKey, $problematicNodes);
+        }
+    }
+
+    private function checkTableAccess(array $node, array &$problematicNodes): void
+    {
+        if (! isset($node['table'])) {
+            return;
+        }
+
+        $accessType = strtolower($node['table']['access_type'] ?? '');
+        $usedKey = ! empty($node['table']['key']);
+
+        if ($accessType === 'all' && ! $usedKey) {
+            $problematicNodes[] = $node['table'];
+        }
+    }
+
+    private function processChildNode(array $node, string $childKey, array &$problematicNodes): void
+    {
+        if (empty($node[$childKey]) || ! is_array($node[$childKey])) {
+            return;
+        }
+
+        if ($this->isSequentialArray($node[$childKey])) {
+            foreach ($node[$childKey] as $childNode) {
+                if (is_array($childNode)) {
+                    $this->analyzeJsonExplainNode($childNode, $problematicNodes);
+                }
+            }
+
+            return;
+        }
+
+        $this->analyzeJsonExplainNode($node[$childKey], $problematicNodes);
+    }
+
+    private function isSequentialArray(array $array): bool
+    {
+        return array_keys($array) === range(0, count($array) - 1);
     }
 
     private function resolveRequestContext(): array
     {
         $request = request();
-
         $queryString = $request->getQueryString();
-        $uri = str($request->getPathInfo().($queryString ? "?$queryString" : ''))
-            ->ltrim('/')
-            ->toString();
-
-        $origin = ($request->server('argv') && $request->server('SCRIPT_NAME') === 'artisan')
-            ? 'console'
-            : 'http';
 
         return [
-            'origin' => $origin,
+            'origin' => $this->resolveRequestOrigin($request),
             'argv' => $request->server('argv'),
-            'uri' => $uri,
+            'uri' => $this->buildRequestUri($request, $queryString),
             'method' => $request->getMethod(),
         ];
+    }
+
+    private function resolveRequestOrigin(Request $request): string
+    {
+        return ($request->server('argv') && $request->server('SCRIPT_NAME') === 'artisan')
+            ? 'console'
+            : 'http';
+    }
+
+    private function buildRequestUri(Request $request, ?string $queryString): string
+    {
+        return str($request->getPathInfo().($queryString ? "?$queryString" : ''))
+            ->ltrim('/')
+            ->toString();
     }
 }


### PR DESCRIPTION
### Query Explain

Adds EXPLAIN support for query analysis.
This feature runs the EXPLAIN command before executing a query, returning details about the database execution plan.
The results help identify bottlenecks, such as full table scans, unused indexes, or inefficient joins.

```yaml
queries:
  explain: true
```

<img width="775" height="216" alt="image" src="https://github.com/user-attachments/assets/165dcfaf-de60-4b9e-a3fc-7cd86d333918" />

<img width="777" height="608" alt="image" src="https://github.com/user-attachments/assets/928d2f5c-ba3d-42ab-a4a1-e71ce21a317b" />

