### PR TITLE
[chore] Pest V4 and improve existing tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "orchestra/testbench-core": "^8.0|^9.4|^10.0",
         "laravel/framework": "^10.0|^11.0|^12.0",
         "symfony/var-dumper": "^6.4.0|^7.1.3",
-        "pestphp/pest": "^2.35.1|^3.7.0",
+        "pestphp/pest": "^4.0.0|^3.7.0|^2.35.1",
         "laravel/pint": "^1.17.2",
         "mockery/mockery": "^1.6.12",
         "livewire/livewire": "^3.5.6",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" colors="true" cacheDirectory=".phpunit.cache">
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
   <testsuites>
     <testsuite name="Test Suite">
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
   </testsuites>
-  <coverage>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
   <php>
     <server name="APP_ENV" value="testing"/>
     <server name="DB_DRIVER" value="sqlite"/>

--- a/tests/Feature/ArchTest.php
+++ b/tests/Feature/ArchTest.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+arch('does not use debug functions')
+    ->expect(['dd', 'dump', 'ray', 'die', 'var_dump', 'sleep', 'exit'])
+    ->not->toBeUsed();

--- a/tests/Feature/ParseDefaultConfigTest.php
+++ b/tests/Feature/ParseDefaultConfigTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
+
+it('parses the config yaml base file', function () {
+    expect(Yaml::parseFile('src/Commands/laradumps-base.yaml'))
+        ->not->toThrow(ParseException::class)
+        ->toBe(
+            [
+                'observers' => [
+                    'dump' => false,
+                    'original_dump' => true,
+                    'auto_invoke_app' => false,
+                    'enabled_in_testing' => false,
+                    'queries' => false,
+                    'slow_queries' => false,
+                    'mail' => false,
+                    'logs' => true,
+                    'http' => false,
+                    'jobs' => false,
+                    'commands' => false,
+                    'scheduled_commands' => false,
+                    'gate' => false,
+                    'cache' => false,
+                ],
+                'logs' => [
+                    'info' => true,
+                    'warning' => true,
+                    'emergency' => true,
+                    'alert' => false,
+                    'debug' => true,
+                    'error' => true,
+                    'critical' => true,
+                    'notice' => true,
+                    'vendor' => true,
+                    'deprecated_message' => true,
+                ],
+                'slow_queries' => [
+                    'threshold_in_ms' => 500,
+                ],
+                'extra' => [
+                    'context' => false,
+                ],
+                'queries' => [
+                    'explain' => false,
+                ]]
+        );
+});

--- a/tests/Feature/StrCutTest.php
+++ b/tests/Feature/StrCutTest.php
@@ -1,4 +1,3 @@
-
 <?php
 
 it('properly cuts dump string')
@@ -15,11 +14,14 @@ END;
 
     return base64_decode($html);
 }
+
 function htmlDump(): string
 {
+
     $html = <<< 'END'
     PHByZSBjbGFzcz1zZi1kdW1wIGlkPXNmLWR1bXAtMTAzNDkyODg3MiBkYXRhLWluZGVudC1wYWQ9IiAgIj4iPHNwYW4gY2xhc3M9c2YtZHVtcC1zdHIgdGl0bGU9IjQwIGNoYXJhY3RlcnMiPkl0IHdvcmtzISBUaGFuayB5b3UgZm9yIHVzaW5nIExhcmFEdW1wcyE8L3NwYW4+Ig0KPC9wcmU+
     END;
 
     return base64_decode($html);
+
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -22,6 +22,9 @@ class TestCase extends BaseTestCase
 
     protected function tearDown(): void
     {
+
+        parent::tearDown();
+
         \Mockery::close();
     }
 


### PR DESCRIPTION
# 🛻 LaraDumps Pull Request

Welcome and thank you for your interest in contributing to our project.

`   🗒️ `  Please read the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md) and follow all steps listed there.

### Motivation

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change

### Description

Hi Luan, this PR aims to fix the  following two issues regarding the outdated PHPUnit XML file and the empty info message while running tests:

<img width="1766" height="430" alt="CleanShot 2025-08-21 at 19 04 50@2x" src="https://github.com/user-attachments/assets/a8446577-6f49-4980-80e6-5ca6056fb88d" />


In addition, I have added a basic *Architectural test* and a test for parsing the base configuration YAML file. The last one could detect and prevent shipping new versions with lint errors or typos in the base config. 

I decided to track every default configuration key in the test so it can function as a "snapshot" as well.

### Documentation

 This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [X] No
- [ ] I have already submitted a Documentation pull request.