### PR TITLE
fix: :sparkles: avoid duplicate entries when adding 'laradumps.yaml'

### DIFF
--- a/src/Actions/AppendLaradumpsYamlToGitignore.php
+++ b/src/Actions/AppendLaradumpsYamlToGitignore.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Actions;
+
+final class AppendLaradumpsYamlToGitignore
+{
+    public static function handle(): bool
+    {
+
+        if (! file_exists('.gitignore') || str_contains(file_get_contents('.gitignore'), 'laradumps.yaml')) {
+            return false;
+        }
+
+        file_put_contents('.gitignore', 'laradumps.yaml'.PHP_EOL, FILE_APPEND);
+
+        return true;
+
+    }
+}

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -3,6 +3,7 @@
 namespace LaraDumps\LaraDumps\Commands;
 
 use Illuminate\Console\Command;
+use LaraDumps\LaraDumps\Actions\AppendLaradumpsYamlToGitignore;
 use LaraDumps\LaraDumpsCore\Actions\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Yaml\Yaml;
@@ -72,23 +73,13 @@ class InitCommand extends Command
 
         ds('Welcome to the LaraDumps!');
 
-        $this->components->info('The laradumps.yaml file was published in <comment>'.$pwd.'</comment>');
-        $this->components->info('Read the docs: https://laradumps.dev/debug/usage.html');
+        $this->components->info('The <comment>laradumps.yaml</comment> configuration file was published at <comment>'.$pwd.'</comment>');
 
-        $gitignorePath = '.gitignore';
-        $lineToAdd = 'laradumps.yaml';
-
-        $gitignoreContent = file_exists($gitignorePath) ? file_get_contents($gitignorePath) : '';
-
-        $lines = array_filter(array_map('trim', explode("\n", $gitignoreContent)));
-
-        if (! in_array($lineToAdd, $lines)) {
-            $lines[] = $lineToAdd;
-
-            file_put_contents($gitignorePath, implode("\n", $lines)."\n");
-            $this->components->info("'laradumps.yaml' file was added to .gitignore");
-        } else {
-            $this->components->info("'laradumps.yaml' has already been added to .gitignore");
+        if (AppendLaradumpsYamlToGitignore::handle()) {
+            $this->components->info('<comment>laradumps.yaml</comment> was added to <comment>.gitignore</comment>');
         }
+
+        $this->components->info('Check out our documentation at <comment>https://laradumps.dev/</comment>');
+
     }
 }

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -3,7 +3,6 @@
 namespace LaraDumps\LaraDumps\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Process;
 use LaraDumps\LaraDumpsCore\Actions\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Yaml\Yaml;
@@ -76,6 +75,20 @@ class InitCommand extends Command
         $this->components->info('The laradumps.yaml file was published in <comment>'.$pwd.'</comment>');
         $this->components->info('Read the docs: https://laradumps.dev/debug/usage.html');
 
-        Process::run('echo "laradumps.yaml" >> .gitignore');
+        $gitignorePath = '.gitignore';
+        $lineToAdd = 'laradumps.yaml';
+
+        $gitignoreContent = file_exists($gitignorePath) ? file_get_contents($gitignorePath) : '';
+
+        $lines = array_filter(array_map('trim', explode("\n", $gitignoreContent)));
+
+        if (! in_array($lineToAdd, $lines)) {
+            $lines[] = $lineToAdd;
+
+            file_put_contents($gitignorePath, implode("\n", $lines)."\n");
+            $this->components->info("'laradumps.yaml' file was added to .gitignore");
+        } else {
+            $this->components->info("'laradumps.yaml' has already been added to .gitignore");
+        }
     }
 }


### PR DESCRIPTION
# 🛻 LaraDumps Pull Request

Welcome and thank you for your interest in contributing to our project.

`   🗒️ `  Please read the [Contributing Guide](https://github.com/laradumps/laradumps/blob/main/CONTRIBUTING.md) and follow all steps listed there.

### Motivation

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

### Related Issue(s)

This PR fixes the Issue #235 

### Description

This Pull Request fixes an issue where `laradumps.yaml` was added multiple times to `.gitignore` when running the command more than once. The fix ensures that duplicate entries are not added.

### Documentation

This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

- [ ] Yes
- [x] No
- [ ] I have already submitted a Documentation pull request.
