### PR TITLE
Handle DateTime bindings in SQL interpolation

### DIFF
--- a/src/Observers/LogObserver.php
+++ b/src/Observers/LogObserver.php
@@ -157,7 +157,7 @@ class LogObserver extends BaseObserver
     private function interpolateBindings(string $sql, array $bindings): ?string
     {
         foreach ($bindings as $binding) {
-            if($binding instanceof DateTime) {
+            if ($binding instanceof DateTime) {
                 $binding = $binding->format('Y-m-d H:i:s');
             }
 

--- a/src/Observers/LogObserver.php
+++ b/src/Observers/LogObserver.php
@@ -3,6 +3,7 @@
 namespace LaraDumps\LaraDumps\Observers;
 
 use Closure;
+use DateTime;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Http\Request;
 use Illuminate\Log\Events\MessageLogged;
@@ -156,6 +157,10 @@ class LogObserver extends BaseObserver
     private function interpolateBindings(string $sql, array $bindings): ?string
     {
         foreach ($bindings as $binding) {
+            if($binding instanceof DateTime) {
+                $binding = $binding->format('Y-m-d H:i:s');
+            }
+
             $replacement = match (gettype($binding)) {
                 'integer', 'double' => $binding,
                 'NULL' => 'NULL',


### PR DESCRIPTION
### Motivation

Bug fix

### Related Issue(s)

No related

### Description

Added support for formatting DateTime objects as 'Y-m-d H:i:s' when interpolating SQL bindings in LogObserver. This ensures that DateTime values are correctly represented in the generated SQL strings.

Error before: Uncaught Error: Object of class DateTime could not be converted to string in vendor/laradumps/laradumps/src/Observers/LogObserver.php:163

### Documentation

This PR requires [Documentation](https://github.com/laradumps/laradumps-docs) update?

No

