### PR TITLE
Updated the `laradumps/laradumps-core` to require only `^4.0.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         "nunomaduro/termwind": "^2.3.3",
         "illuminate/support": "^11.0|^12.0",
         "illuminate/mail": "^11.0|^12.0",
-        "laradumps/laradumps-core": "^3.2.11|^4.0.0"
+        "laradumps/laradumps-core": "^4.0.0"
     },
     "require-dev": {
         "orchestra/testbench-core": "^9.4|^10.0",
         "laravel/framework": "^11.0|^12.0",
         "symfony/var-dumper": "^7.1.3|^8.0",
-        "pestphp/pest": "^3.7.0|^4.0.0",
+        "pestphp/pest": "^4.0.0",
         "laravel/pint": "^1.26.0",
         "mockery/mockery": "^1.6.12",
         "livewire/livewire": "^3.7.1|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "orchestra/testbench-core": "^9.4|^10.0",
         "laravel/framework": "^11.0|^12.0",
         "symfony/var-dumper": "^7.1.3|^8.0",
-        "pestphp/pest": "^4.0.0",
+        "pestphp/pest": "^3.7.0|^4.0.0",
         "laravel/pint": "^1.26.0",
         "mockery/mockery": "^1.6.12",
         "livewire/livewire": "^3.7.1|^4.0",


### PR DESCRIPTION
- Updated the `laradumps/laradumps-core` dependency in `composer.json` to require only `^4.0.0`