### PR TITLE
chore: remove requirement for nunomaduro/termwind

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,9 @@
     ],
     "require": {
         "php": "^8.2",
-        "nunomaduro/termwind": "^2.3.3",
         "illuminate/support": "^11.0|^12.0",
         "illuminate/mail": "^11.0|^12.0",
-        "laradumps/laradumps-core": "^4.0.0"
+        "laradumps/laradumps-core": "^4.0.1"
     },
     "require-dev": {
         "orchestra/testbench-core": "^9.4|^10.0",


### PR DESCRIPTION
This pull request makes a minor update to the project's dependencies in `composer.json`. The only change is upgrading the `laradumps/laradumps-core` package to version `^4.0.1` and removing the unused `nunomaduro/termwind` dependency.