### PR TITLE
Fix HttpClientObserver to handle non-seekable streams

### DIFF
--- a/src/Observers/HttpClientObserver.php
+++ b/src/Observers/HttpClientObserver.php
@@ -89,11 +89,19 @@ class HttpClientObserver extends BaseObserver
 
     private function getResponseBody(Response $response): mixed
     {
-        return rescue(
+        $stream = $response->toPsrResponse()->getBody();
+        if (! $stream->isSeekable()) {
+            return 'Stream Response';
+        }
+        $body = rescue(
             fn () => $response->json(),
             Dumper::dump($response->body())[0],
             report: false
         );
+
+        $stream->rewind();
+
+        return $body;
     }
 
     private function sendPayload(Payload $payload): void

--- a/tests/Feature/Observers/HttpClientObserverTest.php
+++ b/tests/Feature/Observers/HttpClientObserverTest.php
@@ -4,25 +4,19 @@ use Illuminate\Http\Client\Response;
 use LaraDumps\LaraDumps\Observers\HttpClientObserver;
 
 it('handles non-seekable stream responses without errors', function () {
-    // Create a mock non-seekable stream
     $stream = Mockery::mock(\Psr\Http\Message\StreamInterface::class);
     $stream->shouldReceive('isSeekable')->andReturn(false);
 
-    // Create a mock PSR response
     $psrResponse = Mockery::mock(\Psr\Http\Message\ResponseInterface::class);
     $psrResponse->shouldReceive('getBody')->andReturn($stream);
 
-    // Create a mock Laravel Response
     $response = Mockery::mock(Response::class)->makePartial();
     $response->shouldReceive('toPsrResponse')->andReturn($psrResponse);
 
-    // Create observer instance
     $observer = new HttpClientObserver();
 
-    // Use reflection to call the private getResponseBody method
     $reflection = new ReflectionClass($observer);
     $method = $reflection->getMethod('getResponseBody');
-    $method->setAccessible(true);
 
     $result = $method->invoke($observer, $response);
 
@@ -30,33 +24,26 @@ it('handles non-seekable stream responses without errors', function () {
 });
 
 it('rewinds seekable streams after reading', function () {
-    // Create a mock seekable stream
     $stream = Mockery::mock(\Psr\Http\Message\StreamInterface::class);
     $stream->shouldReceive('isSeekable')->andReturn(true);
     $stream->shouldReceive('rewind')->once();
 
-    // Create a mock PSR response
     $psrResponse = Mockery::mock(\Psr\Http\Message\ResponseInterface::class);
     $psrResponse->shouldReceive('getBody')->andReturn($stream);
 
-    // Create a mock Laravel Response
     $response = Mockery::mock(Response::class);
     $response->shouldReceive('toPsrResponse')->andReturn($psrResponse);
     $response->shouldReceive('json')->andReturn(['data' => 'test']);
     $response->shouldReceive('body')->andReturn('{"data":"test"}');
 
-    // Create observer instance
     $observer = new HttpClientObserver();
 
-    // Use reflection to call the private getResponseBody method
     $reflection = new ReflectionClass($observer);
     $method = $reflection->getMethod('getResponseBody');
-    $method->setAccessible(true);
 
     $result = $method->invoke($observer, $response);
 
     expect($result)->toBe(['data' => 'test']);
-    // The expectation that rewind() was called once is verified by Mockery
 });
 
 it('falls back to body dump when json parsing fails', function () {
@@ -81,10 +68,8 @@ it('falls back to body dump when json parsing fails', function () {
     // Use reflection to call the private getResponseBody method
     $reflection = new ReflectionClass($observer);
     $method = $reflection->getMethod('getResponseBody');
-    $method->setAccessible(true);
 
     $result = $method->invoke($observer, $response);
 
     expect($result)->toBeString();
-    // The result will be the dumped version of 'plain text response'
 });

--- a/tests/Feature/Observers/HttpClientObserverTest.php
+++ b/tests/Feature/Observers/HttpClientObserverTest.php
@@ -1,0 +1,90 @@
+<?php
+
+use Illuminate\Http\Client\{Response};
+use LaraDumps\LaraDumps\Observers\HttpClientObserver;
+
+it('handles non-seekable stream responses without errors', function () {
+    // Create a mock non-seekable stream
+    $stream = Mockery::mock(\Psr\Http\Message\StreamInterface::class);
+    $stream->shouldReceive('isSeekable')->andReturn(false);
+
+    // Create a mock PSR response
+    $psrResponse = Mockery::mock(\Psr\Http\Message\ResponseInterface::class);
+    $psrResponse->shouldReceive('getBody')->andReturn($stream);
+
+    // Create a mock Laravel Response
+    $response = Mockery::mock(Response::class)->makePartial();
+    $response->shouldReceive('toPsrResponse')->andReturn($psrResponse);
+
+    // Create observer instance
+    $observer = new HttpClientObserver();
+
+    // Use reflection to call the private getResponseBody method
+    $reflection = new ReflectionClass($observer);
+    $method = $reflection->getMethod('getResponseBody');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($observer, $response);
+
+    expect($result)->toBe('Stream Response');
+});
+
+it('rewinds seekable streams after reading', function () {
+    // Create a mock seekable stream
+    $stream = Mockery::mock(\Psr\Http\Message\StreamInterface::class);
+    $stream->shouldReceive('isSeekable')->andReturn(true);
+    $stream->shouldReceive('rewind')->once();
+
+    // Create a mock PSR response
+    $psrResponse = Mockery::mock(\Psr\Http\Message\ResponseInterface::class);
+    $psrResponse->shouldReceive('getBody')->andReturn($stream);
+
+    // Create a mock Laravel Response
+    $response = Mockery::mock(Response::class);
+    $response->shouldReceive('toPsrResponse')->andReturn($psrResponse);
+    $response->shouldReceive('json')->andReturn(['data' => 'test']);
+    $response->shouldReceive('body')->andReturn('{"data":"test"}');
+
+    // Create observer instance
+    $observer = new HttpClientObserver();
+
+    // Use reflection to call the private getResponseBody method
+    $reflection = new ReflectionClass($observer);
+    $method = $reflection->getMethod('getResponseBody');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($observer, $response);
+
+    expect($result)->toBe(['data' => 'test']);
+    // The expectation that rewind() was called once is verified by Mockery
+});
+
+it('falls back to body dump when json parsing fails', function () {
+    // Create a mock seekable stream
+    $stream = Mockery::mock(\Psr\Http\Message\StreamInterface::class);
+    $stream->shouldReceive('isSeekable')->andReturn(true);
+    $stream->shouldReceive('rewind')->once();
+
+    // Create a mock PSR response
+    $psrResponse = Mockery::mock(\Psr\Http\Message\ResponseInterface::class);
+    $psrResponse->shouldReceive('getBody')->andReturn($stream);
+
+    // Create a mock Laravel Response
+    $response = Mockery::mock(Response::class)->makePartial();
+    $response->shouldReceive('toPsrResponse')->andReturn($psrResponse);
+    $response->shouldReceive('json')->andThrow(new \Exception('Invalid JSON'));
+    $response->shouldReceive('body')->andReturn('plain text response');
+
+    // Create observer instance
+    $observer = new HttpClientObserver();
+
+    // Use reflection to call the private getResponseBody method
+    $reflection = new ReflectionClass($observer);
+    $method = $reflection->getMethod('getResponseBody');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($observer, $response);
+
+    expect($result)->toBeString();
+    // The result will be the dumped version of 'plain text response'
+});

--- a/tests/Feature/Observers/HttpClientObserverTest.php
+++ b/tests/Feature/Observers/HttpClientObserverTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Http\Client\{Response};
+use Illuminate\Http\Client\Response;
 use LaraDumps\LaraDumps\Observers\HttpClientObserver;
 
 it('handles non-seekable stream responses without errors', function () {


### PR DESCRIPTION
## Summary

This PR fixes an issue in `HttpClientObserver` where HTTP responses with non-seekable streams (such as chunked responses or stream responses) would cause errors.

## Problem

When reading the response body, the stream is consumed. Attempting to read it again without rewinding causes an error. However, non-seekable streams cannot be rewound, leading to failures when observing certain HTTP responses.

## How to Reproduce

With the `laravel/ai` package and a sample agent, you can reproduce this issue:

```bash
php artisan make:agent TestAgent
```

Then create a debug route:

```php
Route::get('debug', function(){
    return (new \App\Ai\Agents\TestAgent())->stream('test');
});
```


### Before Fix
<img width="2788" height="1019" alt="before-bugfix" src="https://github.com/user-attachments/assets/6530d413-4ee9-4220-b5ea-bb071ede031a" />


The Body field shows an error or malformed data when trying to read non-seekable streams.

### After Fix
<img width="3365" height="1024" alt="post-bugfix" src="https://github.com/user-attachments/assets/f78cbfb8-7e1d-48f5-95d0-a726d3829920" />
The Body field now correctly displays `Stream Response` for non-seekable streams.

## Solution

- Check if the response stream is seekable before attempting to read the body
- Return a `'Stream Response'` placeholder for non-seekable streams
- Rewind the stream after reading for seekable streams to restore the original state

## Related

This fix mirrors the approach taken in Laravel Telescope to address the same issue:
- https://github.com/laravel/telescope/pull/1625
- https://github.com/laravel/telescope/pull/1621

## Changes

- Modified `getResponseBody()` method in `src/Observers/HttpClientObserver.php` (lines 90-104)