### PR TITLE
feat: add option to ignore boost browser info logs in LogObserver

### DIFF
--- a/src/Commands/laradumps-base.yaml
+++ b/src/Commands/laradumps-base.yaml
@@ -25,6 +25,7 @@ logs:
   notice: true
   vendor: true
   deprecated_message: true
+  boost_info: false
 slow_queries:
   threshold_in_ms: 500
 extra:

--- a/src/Observers/LogObserver.php
+++ b/src/Observers/LogObserver.php
@@ -88,6 +88,13 @@ class LogObserver extends BaseObserver
             return false;
         }
 
+        if ($level === 'info' && ! data_get($config, 'boost_info')) {
+            $routeName = $this->request->route()?->getName();
+            if ($routeName === 'boost.browser-logs') {
+                return false;
+            }
+        }
+
         return match ($level) {
             'vendor' => str_contains($message, 'vendor'),
             'deprecated_message' => str_contains($message, 'deprecated'),

--- a/tests/Feature/ParseDefaultConfigTest.php
+++ b/tests/Feature/ParseDefaultConfigTest.php
@@ -36,6 +36,7 @@ it('parses the config yaml base file', function () {
                     'notice' => true,
                     'vendor' => true,
                     'deprecated_message' => true,
+                    'boost_info' => false,
                 ],
                 'slow_queries' => [
                     'threshold_in_ms' => 500,


### PR DESCRIPTION
This pull request introduces a configuration option to control logging of "boost info" messages and updates the log observer logic to respect this setting. The main focus is to allow users to disable logging of certain info-level messages related to the `boost.browser-logs` route.

Configuration changes:

* Added a new `boost_info` setting to the `logs` section in `src/Commands/laradumps-base.yaml`, defaulting to `false`, which allows users to control whether boost info messages are logged.

Logging logic updates:

* Updated the `shouldLogMessage` method in `src/Observers/LogObserver.php` to check the `boost_info` config. When disabled, info-level messages from the `boost.browser-logs` route will not be logged.