### PR TITLE
Brain: Replace Process/Task to Workflow/Action

### DIFF
--- a/src/Observers/BrainObserver.php
+++ b/src/Observers/BrainObserver.php
@@ -2,13 +2,12 @@
 
 namespace LaraDumps\LaraDumps\Observers;
 
-use Brain\Processes\Events\{Error as ProcessError, Processed as ProcessProcessed, Processing as ProcessProcessing};
-use Brain\Tasks\Events\{Cancelled as TaskCancelled, Error as TaskError, Processed as TaskProcessed, Processing as TaskProcessing, Skipped as TaskSkipped};
 use Illuminate\Support\Facades\Event;
 use LaraDumps\LaraDumps\Payloads\BrainPayload;
 use LaraDumps\LaraDumpsCore\Actions\Dumper;
 use LaraDumps\LaraDumpsCore\LaraDumps;
 use LaraDumps\LaraDumpsCore\Payloads\Payload;
+use ReflectionClass;
 use Spatie\Backtrace\{Backtrace, Frame};
 
 class BrainObserver extends BaseObserver
@@ -16,28 +15,20 @@ class BrainObserver extends BaseObserver
     public function register(): void
     {
         Event::listen([
-            ProcessProcessing::class,
-            ProcessProcessed::class,
-            ProcessError::class,
-            TaskProcessing::class,
-            TaskProcessed::class,
-            TaskCancelled::class,
-            TaskSkipped::class,
-            TaskError::class,
-        ], fn (object $event) => $this->handle($event));
+            'Brain\\Workflows\\Events\\*',
+            'Brain\\Actions\\Events\\*',
+        ], fn (string $eventName, array $data) => $this->handle($data[0]));
     }
 
     private function handle(object $event): void
     {
-        if (! class_exists(ProcessProcessing::class) && ! class_exists(TaskProcessing::class)) {
-            return;
-        }
-
         if (! $this->isEnabled('brain')) {
             return;
         }
 
-        if (blank($event->runProcessId)) {
+        $runWorkflowId = $event->runWorkflowId ?? null;
+
+        if (blank($runWorkflowId)) {
             return;
         }
 
@@ -54,11 +45,11 @@ class BrainObserver extends BaseObserver
                 $class = $frame->class ?? '';
                 $file = $frame->file ?? '';
 
-                if (str_contains($class, 'Brain\\Process')) {
+                if (str_contains($class, 'Brain\\Workflow')) {
                     return false;
                 }
 
-                if (str_contains($class, 'Brain\\Task')) {
+                if (str_contains($class, 'Brain\\Action')) {
                     return false;
                 }
 
@@ -74,7 +65,7 @@ class BrainObserver extends BaseObserver
             })
             ->first();
 
-        $payload = $this->generatePayload($event);
+        $payload = $this->generatePayload($event, (string) $runWorkflowId);
 
         $payload->setFrame(filled($frame) ? [
             'file' => $frame->file,
@@ -87,49 +78,29 @@ class BrainObserver extends BaseObserver
         $this->sendPayload($payload);
     }
 
-    private function generatePayload(object $event): Payload
+    private function generatePayload(object $event, string $runWorkflowId): Payload
     {
         $className = get_class($event);
 
-        $runProcessId = $event->runProcessId;
         $payload = $event->payload;
         $meta = $event->meta;
 
-        if (str_contains($className, 'Brain\\Processes\\Events')) {
-            $process = $event->process;
+        $type = 'action';
 
-            return new BrainPayload(
-                className: $process,
-                runProcessId: (string) $runProcessId,
-                payload: Dumper::dump($payload),
-                meta: $meta,
-                status: $this->getLabelClassNameBased($className),
-                type: 'process'
-            );
-        }
-
-        $task = $event->task;
+        $brainClassName = match (true) {
+            str_contains($className, 'Actions') => $event->action,
+            str_contains($className, 'Workflows') => $event->workflow,
+            default => 'Unknown',
+        };
 
         return new BrainPayload(
-            className: $task,
-            runProcessId: $runProcessId,
+            className: $brainClassName,
+            runWorkflowId: $runWorkflowId,
             payload: Dumper::dump($payload),
             meta: $meta,
-            status: $this->getLabelClassNameBased($className),
-            type: 'task'
+            status: (new ReflectionClass($event))->getShortName(),
+            type: $type
         );
-    }
-
-    private function getLabelClassNameBased(string $className): string
-    {
-        return match (true) {
-            $className === ProcessProcessing::class, $className === TaskProcessing::class => 'Processing',
-            $className === ProcessProcessed::class, $className === TaskProcessed::class => 'Processed',
-            $className === ProcessError::class, $className === TaskError::class => 'Error',
-            $className === TaskCancelled::class => 'Cancelled',
-            $className === TaskSkipped::class => 'Skipped',
-            default => 'Stale',
-        };
     }
 
     private function sendPayload(Payload $payload): void

--- a/src/Payloads/BrainPayload.php
+++ b/src/Payloads/BrainPayload.php
@@ -8,11 +8,11 @@ class BrainPayload extends Payload
 {
     public function __construct(
         public mixed $className = '',
-        public string $runProcessId = '',
+        public string $runWorkflowId = '',
         public mixed $payload = null,
         public array $meta = [],
         public string $status = '',
-        public string $type = 'process'
+        public string $type = 'workflow'
     ) {}
 
     public function type(): string
@@ -34,7 +34,7 @@ class BrainPayload extends Payload
     {
         return [
             'className' => $this->className,
-            'run_process_id' => $this->runProcessId,
+            'run_workflow_id' => $this->runWorkflowId,
             'payload' => $this->payload,
             'meta' => $this->meta,
             'status' => $this->status,


### PR DESCRIPTION
This pull request updates the `BrainObserver` and `BrainPayload` classes to support a new event structure based on workflows and actions, replacing the previous process/task-based approach. The changes primarily update event listening, payload generation, and field naming to align with the new `Workflow` and `Action` terminology, ensuring compatibility with the refactored Brain event system.

**Event handling and payload generation updates:**

* Changed event listener registration in `BrainObserver` to listen for wildcard events under `Brain\Workflows\Events\*` and `Brain\Actions\Events\*`, and updated the event handler signature to match the new event structure.
* Updated the filtering logic in the stack trace to ignore frames from `Brain\Workflow` and `Brain\Action` classes instead of the old `Brain\Process` and `Brain\Task` classes.
* Modified the payload generation to use `runWorkflowId` instead of `runProcessId`, and to extract the relevant class name from the new event types (`action` or `workflow`). The payload type is now always set to `'action'` and the status is derived from the event class name. [[1]](diffhunk://#diff-e6ab786d912823cf57e1a05391b5ae9160a07bc09d318fa9fdb558d03887c35bL77-R68) [[2]](diffhunk://#diff-e6ab786d912823cf57e1a05391b5ae9160a07bc09d318fa9fdb558d03887c35bL90-L134)

**Payload structure changes:**

* Updated the `BrainPayload` constructor and content to use `runWorkflowId` and `run_workflow_id` instead of `runProcessId`/`run_process_id`, and set the default type to `'workflow'`. [[1]](diffhunk://#diff-f6a37f6b8fed49fe99b30367a791c5a1925545b0da0509df56038605d835e4e0L11-R15) [[2]](diffhunk://#diff-f6a37f6b8fed49fe99b30367a791c5a1925545b0da0509df56038605d835e4e0L37-R37)