### PR TITLE
feat: implement JobContext for managing job-related data during proce…

### DIFF
--- a/src/LaraDumps.php
+++ b/src/LaraDumps.php
@@ -9,7 +9,10 @@ use LaraDumps\LaraDumps\Livewire\Support\Debug;
 use LaraDumps\LaraDumps\Observers\{CacheObserver, CommandObserver, GateObserver, HttpClientObserver, ProfileObserver, QueryObserver, ScheduledCommandObserver};
 use LaraDumps\LaraDumps\Payloads\{ContextPayload, MailablePayload, MarkdownPayload, ModelPayload, ProfilePayload, RoutesPayload};
 use LaraDumps\LaraDumps\Profile\ProfileManager;
+use LaraDumps\LaraDumps\Support\JobContext;
+use LaraDumps\LaraDumpsCore\Dispatcher\Dispatcher;
 use LaraDumps\LaraDumpsCore\LaraDumps as BaseLaraDumps;
+use LaraDumps\LaraDumpsCore\Payloads\Payload;
 use Livewire\Volt\Component;
 
 class LaraDumps extends BaseLaraDumps
@@ -233,5 +236,14 @@ class LaraDumps extends BaseLaraDumps
     public function measure(string $name, callable $callback, string $type = 'app', array $metadata = []): mixed
     {
         return app(ProfileManager::class)->measure($name, $callback, $type, $metadata);
+    }
+
+    protected function dispatchPayload(Payload $payload): void
+    {
+        $data = $payload->toArray();
+
+        $data['related_job'] = $payload->type() === 'jobs' ? null : JobContext::current();
+
+        (new Dispatcher())->handle($data);
     }
 }

--- a/src/Observers/JobsObserver.php
+++ b/src/Observers/JobsObserver.php
@@ -6,6 +6,7 @@ use Illuminate\Queue\Events\{JobFailed, JobProcessed, JobProcessing, JobQueued};
 use Illuminate\Queue\Jobs\Job;
 use Illuminate\Support\Facades\Event;
 use LaraDumps\LaraDumps\Payloads\JobPayload;
+use LaraDumps\LaraDumps\Support\JobContext;
 use LaraDumps\LaraDumpsCore\LaraDumps;
 use LaraDumps\LaraDumpsCore\Payloads\Payload;
 use LaraDumps\LaraDumpsCore\Support\CodeSnippet;
@@ -28,6 +29,13 @@ class JobsObserver extends BaseObserver
             return;
         }
 
+        if ($event instanceof JobProcessing) {
+            JobContext::push(
+                $this->extractJobPayloadAttribute($event, 'uuid'),
+                $this->extractJobPayloadAttribute($event, 'displayName')
+            );
+        }
+
         $payload = $this->generatePayload($event);
 
         if ($event instanceof JobFailed) {
@@ -37,6 +45,10 @@ class JobsObserver extends BaseObserver
         }
 
         $this->sendPayload($payload);
+
+        if ($event instanceof JobProcessed || $event instanceof JobFailed) {
+            JobContext::pop();
+        }
     }
 
     private function generatePayload(object $event): Payload

--- a/src/Support/JobContext.php
+++ b/src/Support/JobContext.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Support;
+
+final class JobContext
+{
+    /** @var array<int, array{job_id: string, display_name: string}> */
+    private static array $stack = [];
+
+    public static function push(string $jobId, string $displayName): void
+    {
+        self::$stack[] = ['job_id' => $jobId, 'display_name' => $displayName];
+    }
+
+    public static function pop(): void
+    {
+        array_pop(self::$stack);
+    }
+
+    /** @return array{job_id: string, display_name: string}|null */
+    public static function current(): ?array
+    {
+        return empty(self::$stack) ? null : self::$stack[array_key_last(self::$stack)];
+    }
+
+    public static function clear(): void
+    {
+        self::$stack = [];
+    }
+}


### PR DESCRIPTION
This pull request introduces job context tracking to the LaraDumps package, allowing job-related context to be associated with dispatched payloads. The main changes include the addition of a `JobContext` utility, integration of job context management within the jobs observer, and enhancements to payload dispatching to include job context information.

**Job Context Tracking Enhancements:**

* Added a new `JobContext` utility in `src/Support/JobContext.php` to manage a stack of job contexts, providing methods to push, pop, retrieve the current context, and clear the stack.

**Integration with Job Event Handling:**

* Updated `JobsObserver` to push job context information (job UUID and display name) onto the stack when a job starts processing, and pop it when a job is processed or fails. [[1]](diffhunk://#diff-e685cd4ba9cb8a12b39130b86f9dac16f3dcdbe92bfca4422c8bc6ff945350baR32-R38) [[2]](diffhunk://#diff-e685cd4ba9cb8a12b39130b86f9dac16f3dcdbe92bfca4422c8bc6ff945350baR48-R51)
* Imported the new `JobContext` utility into `JobsObserver.php` for use in job event handling.

**Payload Dispatch Improvements:**

* Modified `LaraDumps` to include the current job context in dispatched payloads (except for payloads of type 'jobs') by updating the `dispatchPayload` method.
* Added necessary imports for `JobContext`, `Dispatcher`, and `Payload` in `LaraDumps.php` to support the new functionality.