### PR TITLE
Feat/self heal config

### DIFF
--- a/src/Actions/DefaultConfig.php
+++ b/src/Actions/DefaultConfig.php
@@ -3,31 +3,21 @@
 namespace LaraDumps\LaraDumps\Actions;
 
 use LaraDumps\LaraDumpsCore\Actions\Config;
-use ReflectionClass;
 use Symfony\Component\Yaml\Yaml;
 
 class DefaultConfig
 {
     public static function toArray(): array
     {
-        /** @var array<string, mixed> $core */
-        $core = (array) Yaml::parseFile(self::coreBasePath());
+        return array_replace_recursive(Config::defaults(), self::packageDefaults());
+    }
 
+    public static function packageDefaults(): array
+    {
         /** @var array<string, mixed> $package */
         $package = (array) Yaml::parseFile(self::packageBasePath());
 
-        return array_replace_recursive($core, $package);
-    }
-
-    public static function coreBasePath(): string
-    {
-        $fileName = (new ReflectionClass(Config::class))->getFileName();
-
-        $coreActionsDir = $fileName !== false
-            ? dirname($fileName)
-            : appBasePath().'vendor/laradumps/laradumps-core/src/Actions';
-
-        return $coreActionsDir.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Commands'.DIRECTORY_SEPARATOR.'laradumps-base.yaml';
+        return $package;
     }
 
     public static function packageBasePath(): string

--- a/src/Actions/DefaultConfig.php
+++ b/src/Actions/DefaultConfig.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace LaraDumps\LaraDumps\Actions;
+
+use LaraDumps\LaraDumpsCore\Actions\Config;
+use ReflectionClass;
+use Symfony\Component\Yaml\Yaml;
+
+class DefaultConfig
+{
+    public static function toArray(): array
+    {
+        /** @var array<string, mixed> $core */
+        $core = (array) Yaml::parseFile(self::coreBasePath());
+
+        /** @var array<string, mixed> $package */
+        $package = (array) Yaml::parseFile(self::packageBasePath());
+
+        return array_replace_recursive($core, $package);
+    }
+
+    public static function coreBasePath(): string
+    {
+        $fileName = (new ReflectionClass(Config::class))->getFileName();
+
+        $coreActionsDir = $fileName !== false
+            ? dirname($fileName)
+            : appBasePath().'vendor/laradumps/laradumps-core/src/Actions';
+
+        return $coreActionsDir.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Commands'.DIRECTORY_SEPARATOR.'laradumps-base.yaml';
+    }
+
+    public static function packageBasePath(): string
+    {
+        return __DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Commands'.DIRECTORY_SEPARATOR.'laradumps-base.yaml';
+    }
+}

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -3,7 +3,7 @@
 namespace LaraDumps\LaraDumps\Commands;
 
 use Illuminate\Console\Command;
-use LaraDumps\LaraDumps\Actions\AppendLaradumpsYamlToGitignore;
+use LaraDumps\LaraDumps\Actions\{AppendLaradumpsYamlToGitignore, DefaultConfig};
 use LaraDumps\LaraDumpsCore\Actions\Config;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Yaml\Yaml;
@@ -34,11 +34,9 @@ class InitCommand extends Command
             return;
         }
 
-        $defaultYaml = appBasePath().'vendor/laradumps/laradumps-core/src/Commands/laradumps-base.yaml';
-
         $publish = Config::publish(
             pwd: $pwd.DIRECTORY_SEPARATOR,
-            filepath: $defaultYaml
+            filepath: DefaultConfig::coreBasePath()
         );
 
         if (! $publish) {
@@ -49,26 +47,13 @@ class InitCommand extends Command
 
         $newYaml = appBasePath().'laradumps.yaml';
 
-        /** @var array $yamlFile */
-        $yamlFile = Yaml::parseFile(__DIR__.'/laradumps-base.yaml');
-        /** @var array $default */
-        $default = Yaml::parseFile($defaultYaml);
+        $mergedYaml = DefaultConfig::toArray();
 
-        foreach ($default as $key => $values) {
-            /**
-             * @var string $key1
-             * @var array $values
-             */
-            foreach ($values as $key1 => $value) {
-                $default[$key][$key1] = $value;
-            }
+        if (isset($mergedYaml['app']) && is_array($mergedYaml['app'])) {
+            $mergedYaml['app']['project_path'] = $pwd.DIRECTORY_SEPARATOR;
         }
 
-        $yamlFile['app']['project_path'] = $pwd.DIRECTORY_SEPARATOR;
-
-        $mergedYaml = array_replace_recursive($default, $yamlFile);
-
-        $yaml = Yaml::dump($mergedYaml);
+        $yaml = Yaml::dump($mergedYaml, 4, 2);
         file_put_contents($newYaml, $yaml);
 
         ds('Welcome to the LaraDumps!');

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -36,7 +36,7 @@ class InitCommand extends Command
 
         $publish = Config::publish(
             pwd: $pwd.DIRECTORY_SEPARATOR,
-            filepath: DefaultConfig::coreBasePath()
+            filepath: Config::baseConfigPath()
         );
 
         if (! $publish) {

--- a/src/LaraDumpsServiceProvider.php
+++ b/src/LaraDumpsServiceProvider.php
@@ -37,8 +37,6 @@ class LaraDumpsServiceProvider extends ServiceProvider
             define('LARADUMPS_REQUEST_ID', uniqid());
         }
 
-        $this->reconcileConfig();
-
         $this->publishes([
             __DIR__.'/../resources/config/laradumps.php' => config_path('laradumps.php'),
         ], 'laradumps-config');
@@ -52,33 +50,14 @@ class LaraDumpsServiceProvider extends ServiceProvider
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'laradumps');
     }
 
-    private function reconcileConfig(): void
-    {
-        static $done = false;
-
-        if ($done) {
-            return;
-        }
-
-        $done = true;
-
-        try {
-            if (! Config::exists() || $this->app->environment('production') || runningInTest()) {
-                return;
-            }
-
-            Config::sync(DefaultConfig::toArray());
-        } catch (\Throwable) {
-            // A dev tool must never break the host application.
-        }
-    }
-
     public function register(): void
     {
         $this->mergeConfigFrom(
             __DIR__.'/../resources/config/laradumps.php',
             'laradumps'
         );
+
+        Config::registerDefaults(DefaultConfig::packageDefaults());
 
         $file = str_replace('/', DIRECTORY_SEPARATOR, __DIR__.'/functions.php');
 

--- a/src/LaraDumpsServiceProvider.php
+++ b/src/LaraDumpsServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\{Collection, ServiceProvider, Stringable};
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Testing\TestResponse;
 use Illuminate\View\View;
+use LaraDumps\LaraDumps\Actions\DefaultConfig;
 use LaraDumps\LaraDumps\Commands\InitCommand;
 use LaraDumps\LaraDumps\Middleware\ProfileMiddleware;
 use LaraDumps\LaraDumps\Observers\{BrainObserver,
@@ -36,6 +37,8 @@ class LaraDumpsServiceProvider extends ServiceProvider
             define('LARADUMPS_REQUEST_ID', uniqid());
         }
 
+        $this->reconcileConfig();
+
         $this->publishes([
             __DIR__.'/../resources/config/laradumps.php' => config_path('laradumps.php'),
         ], 'laradumps-config');
@@ -47,6 +50,27 @@ class LaraDumpsServiceProvider extends ServiceProvider
         $this->commands([InitCommand::class]);
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'laradumps');
+    }
+
+    private function reconcileConfig(): void
+    {
+        static $done = false;
+
+        if ($done) {
+            return;
+        }
+
+        $done = true;
+
+        try {
+            if (! Config::exists() || $this->app->environment('production') || runningInTest()) {
+                return;
+            }
+
+            Config::sync(DefaultConfig::toArray());
+        } catch (\Throwable) {
+            // A dev tool must never break the host application.
+        }
     }
 
     public function register(): void

--- a/src/LaraDumpsServiceProvider.php
+++ b/src/LaraDumpsServiceProvider.php
@@ -133,7 +133,7 @@ class LaraDumpsServiceProvider extends ServiceProvider
     {
         Collection::macro('ds', function (string $label = '') {
             $laradumps = new LaraDumps();
-            $laradumps->write($this->items); // @phpstan-ignore-line
+            $laradumps->write($this->all());
 
             if ($label) {
                 $laradumps->label($label);
@@ -144,7 +144,7 @@ class LaraDumpsServiceProvider extends ServiceProvider
 
         Stringable::macro('ds', function (string $label = '') {
             $laradumps = new LaraDumps();
-            $laradumps->write($this->value); // @phpstan-ignore-line
+            $laradumps->write((string) $this);
 
             if ($label) {
                 $laradumps->label($label);

--- a/tests/Feature/DefaultConfigTest.php
+++ b/tests/Feature/DefaultConfigTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use LaraDumps\LaraDumps\Actions\DefaultConfig;
+
+it('merges the core and package base templates into the full schema', function () {
+    $schema = DefaultConfig::toArray();
+
+    expect($schema)->toHaveKeys(['app', 'config', 'xdebug', 'code_snippet']);
+
+    expect($schema)->toHaveKeys(['observers', 'logs', 'slow_queries', 'extra', 'queries', 'profile']);
+
+    expect($schema['config'])->toHaveKey('color_in_screen');
+
+    expect($schema['observers'])->toHaveKeys(['dump', 'original_dump', 'queries', 'logs', 'profile', 'enabled_in_testing']);
+
+    expect($schema['profile']['capture'])->toHaveKey('eloquent');
+});

--- a/tests/Feature/SelfHealConfigTest.php
+++ b/tests/Feature/SelfHealConfigTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use LaraDumps\LaraDumps\Actions\DefaultConfig;
+use LaraDumps\LaraDumpsCore\Actions\Config;
+use Symfony\Component\Yaml\Yaml;
+
+function withTempLaradumpsConfig(array $content, callable $fn): void
+{
+    $dir = sys_get_temp_dir().'/ld_selfheal_'.uniqid();
+    mkdir($dir);
+    $file = $dir.'/laradumps.yaml';
+    file_put_contents($file, Yaml::dump($content, 4, 2));
+
+    $ref = new ReflectionClass(Config::class);
+    $path = $ref->getProperty('configFilePath');
+    $cache = $ref->getProperty('cachedContent');
+    $path->setAccessible(true);
+    $cache->setAccessible(true);
+
+    $origPath = $path->isInitialized() ? $path->getValue() : null;
+    $origCache = $cache->getValue();
+
+    $path->setValue(null, $file);
+    $cache->setValue(null, null);
+
+    try {
+        $fn($file);
+    } finally {
+        if ($origPath !== null) {
+            $path->setValue(null, $origPath);
+        }
+        $cache->setValue(null, $origCache);
+        @unlink($file);
+        @rmdir($dir);
+    }
+}
+
+it('backfills missing keys into a stale config using the real schema', function () {
+    $stale = [
+        'app' => ['project_path' => '/my/project/'],
+        'observers' => ['dump' => true],
+    ];
+
+    withTempLaradumpsConfig($stale, function ($file) {
+        $changed = Config::sync(DefaultConfig::toArray());
+
+        expect($changed)->toBeTrue();
+
+        $written = Yaml::parseFile($file);
+
+        expect($written)->toHaveKeys(['logs', 'profile', 'queries', 'code_snippet', 'xdebug', 'slow_queries']);
+        expect($written['config'])->toHaveKey('color_in_screen');
+        expect($written['profile']['capture'])->toHaveKey('eloquent');
+
+        expect($written['app']['project_path'])->toBe('/my/project/');
+        expect($written['observers']['dump'])->toBeTrue();
+    });
+});
+
+it('prunes keys that are no longer part of the schema', function () {
+    $stale = array_replace_recursive(DefaultConfig::toArray(), [
+        'app' => ['project_path' => '/my/project/'],
+        'observers' => ['obsolete_observer' => true],
+        'removed_section' => ['foo' => 'bar'],
+    ]);
+
+    withTempLaradumpsConfig($stale, function ($file) {
+        Config::sync(DefaultConfig::toArray());
+
+        $written = Yaml::parseFile($file);
+
+        expect($written['observers'])->not->toHaveKey('obsolete_observer');
+        expect($written)->not->toHaveKey('removed_section');
+        expect($written['app']['project_path'])->toBe('/my/project/');
+    });
+});
+
+it('is a no-op when the file already matches the schema', function () {
+    $current = DefaultConfig::toArray();
+    $current['app']['project_path'] = '/my/project/';
+
+    withTempLaradumpsConfig($current, function () {
+        expect(Config::sync(DefaultConfig::toArray()))->toBeFalse();
+    });
+});


### PR DESCRIPTION
This pull request introduces a new centralized configuration merging system for LaraDumps, improves the initialization and self-healing of configuration files, and adds comprehensive tests to ensure configuration integrity. The main changes are the creation of a `DefaultConfig` class to manage and merge default settings, refactoring of the initialization command to use this new system, and the addition of tests for configuration merging and self-healing.

**Configuration Management Improvements:**

* Introduced the `DefaultConfig` class in `src/Actions/DefaultConfig.php` to merge core and package YAML configuration templates, providing a single source of truth for default configuration values.
* Updated the `InitCommand` in `src/Commands/InitCommand.php` to use `DefaultConfig::toArray()` for generating the initial `laradumps.yaml`, simplifying and centralizing default config handling. [[1]](diffhunk://#diff-160e3581def3cbe8aa54c295ace05322d01f00b62eca0e6ec12d5bd5dfba141dL6-R6) [[2]](diffhunk://#diff-160e3581def3cbe8aa54c295ace05322d01f00b62eca0e6ec12d5bd5dfba141dL37-R39) [[3]](diffhunk://#diff-160e3581def3cbe8aa54c295ace05322d01f00b62eca0e6ec12d5bd5dfba141dL52-R56)
* Registered package defaults in the service provider (`src/LaraDumpsServiceProvider.php`) by calling `Config::registerDefaults(DefaultConfig::packageDefaults())`, ensuring package-level defaults are always available. [[1]](diffhunk://#diff-283b0500f69972f33a0bab567cac1428dfd1d0e919a1fcfac3b400a050a8fa2aR11) [[2]](diffhunk://#diff-283b0500f69972f33a0bab567cac1428dfd1d0e919a1fcfac3b400a050a8fa2aR60-R61)

**Testing and Reliability:**

* Added `tests/Feature/DefaultConfigTest.php` to verify that the merged configuration schema contains all required keys and structure.
* Added `tests/Feature/SelfHealConfigTest.php` to ensure the configuration self-heals by backfilling missing keys, pruning obsolete ones, and remaining a no-op when already up-to-date.

These changes make the configuration process more robust, maintainable, and easier to extend, while ensuring that user config files are always consistent with the latest schema.