### PR TITLE
refactor: rename profile config/screen to profiler

### DIFF
--- a/src/Commands/laradumps-base.yaml
+++ b/src/Commands/laradumps-base.yaml
@@ -14,7 +14,7 @@ observers:
   gate: false
   cache: false
   brain: false
-  profile: false
+  profiler: false
 logs:
   info: true
   warning: true
@@ -33,7 +33,7 @@ extra:
   context: false
 queries:
   explain: false
-profile:
+profiler:
   auto_middleware: false
   max_entries: 300
   capture:

--- a/src/LaraDumpsServiceProvider.php
+++ b/src/LaraDumpsServiceProvider.php
@@ -113,11 +113,11 @@ class LaraDumpsServiceProvider extends ServiceProvider
 
     private function registerProfileMiddleware(): void
     {
-        if (! boolval(Config::get('observers.profile', false))) {
+        if (! boolval(Config::get('observers.profiler', false))) {
             return;
         }
 
-        if (! boolval(Config::get('profile.auto_middleware', false))) {
+        if (! boolval(Config::get('profiler.auto_middleware', false))) {
             return;
         }
 

--- a/src/Middleware/ProfileMiddleware.php
+++ b/src/Middleware/ProfileMiddleware.php
@@ -29,11 +29,11 @@ class ProfileMiddleware
 
     private function shouldProfile(): bool
     {
-        if (! boolval(Config::get('observers.profile', false))) {
+        if (! boolval(Config::get('observers.profiler', false))) {
             return false;
         }
 
-        if (! boolval(Config::get('profile.auto_middleware', false))) {
+        if (! boolval(Config::get('profiler.auto_middleware', false))) {
             return false;
         }
 

--- a/src/Observers/ProfileObserver.php
+++ b/src/Observers/ProfileObserver.php
@@ -145,7 +145,7 @@ class ProfileObserver extends BaseObserver
 
     private function shouldRegisterCollector(string $type): bool
     {
-        return boolval(Config::get("profile.capture.{$type}", true));
+        return boolval(Config::get("profiler.capture.{$type}", true));
     }
 
     private function shouldEnableXHProf(): bool

--- a/src/Payloads/ProfilePayload.php
+++ b/src/Payloads/ProfilePayload.php
@@ -36,7 +36,7 @@ class ProfilePayload extends Payload
 
     public function type(): string
     {
-        return 'profile';
+        return 'profiler';
     }
 
     public function content(): array
@@ -54,7 +54,7 @@ class ProfilePayload extends Payload
 
     public function toScreen(): array|Screen
     {
-        return new Screen('profile');
+        return new Screen('profiler');
     }
 
     public function withLabel(): array|Label

--- a/src/Profile/ProfileManager.php
+++ b/src/Profile/ProfileManager.php
@@ -30,7 +30,7 @@ class ProfileManager
     public function __construct()
     {
         $this->stack = new ProfileStack();
-        $this->maxEntries = intval(Config::get('profile.max_entries', 1000));
+        $this->maxEntries = intval(Config::get('profiler.max_entries', 1000));
         $this->loadCaptureConfig();
     }
 
@@ -57,16 +57,16 @@ class ProfileManager
     private function loadCaptureConfig(): void
     {
         $this->captureConfig = [
-            'app' => boolval(Config::get('profile.capture.app', true)),
-            'events' => boolval(Config::get('profile.capture.events', true)),
-            'queries' => boolval(Config::get('profile.capture.queries', true)),
-            'eloquent' => boolval(Config::get('profile.capture.eloquent', true)),
-            'views' => boolval(Config::get('profile.capture.views', true)),
-            'controller' => boolval(Config::get('profile.capture.controller', true)),
-            'http' => boolval(Config::get('profile.capture.http', true)),
-            'cache' => boolval(Config::get('profile.capture.cache', true)),
-            'jobs' => boolval(Config::get('profile.capture.jobs', true)),
-            'method' => boolval(Config::get('profile.capture.method', true)),
+            'app' => boolval(Config::get('profiler.capture.app', true)),
+            'events' => boolval(Config::get('profiler.capture.events', true)),
+            'queries' => boolval(Config::get('profiler.capture.queries', true)),
+            'eloquent' => boolval(Config::get('profiler.capture.eloquent', true)),
+            'views' => boolval(Config::get('profiler.capture.views', true)),
+            'controller' => boolval(Config::get('profiler.capture.controller', true)),
+            'http' => boolval(Config::get('profiler.capture.http', true)),
+            'cache' => boolval(Config::get('profiler.capture.cache', true)),
+            'jobs' => boolval(Config::get('profiler.capture.jobs', true)),
+            'method' => boolval(Config::get('profiler.capture.method', true)),
         ];
     }
 

--- a/tests/Feature/DefaultConfigTest.php
+++ b/tests/Feature/DefaultConfigTest.php
@@ -5,13 +5,9 @@ use LaraDumps\LaraDumps\Actions\DefaultConfig;
 it('merges the core and package base templates into the full schema', function () {
     $schema = DefaultConfig::toArray();
 
-    expect($schema)->toHaveKeys(['app', 'config', 'xdebug', 'code_snippet']);
-
-    expect($schema)->toHaveKeys(['observers', 'logs', 'slow_queries', 'extra', 'queries', 'profile']);
-
-    expect($schema['config'])->toHaveKey('color_in_screen');
-
-    expect($schema['observers'])->toHaveKeys(['dump', 'original_dump', 'queries', 'logs', 'profile', 'enabled_in_testing']);
-
-    expect($schema['profile']['capture'])->toHaveKey('eloquent');
+    expect($schema)->toHaveKeys(['app', 'config', 'xdebug', 'code_snippet'])
+        ->and($schema)->toHaveKeys(['observers', 'logs', 'slow_queries', 'extra', 'queries', 'profiler'])
+        ->and($schema['config'])->toHaveKey('color_in_screen')
+        ->and($schema['observers'])->toHaveKeys(['dump', 'original_dump', 'queries', 'logs', 'profiler', 'enabled_in_testing'])
+        ->and($schema['profiler']['capture'])->toHaveKey('eloquent');
 });

--- a/tests/Feature/ParseDefaultConfigTest.php
+++ b/tests/Feature/ParseDefaultConfigTest.php
@@ -24,7 +24,7 @@ it('parses the config yaml base file', function () {
                     'gate' => false,
                     'cache' => false,
                     'brain' => false,
-                    'profile' => false,
+                    'profiler' => false,
                 ],
                 'logs' => [
                     'info' => true,
@@ -48,7 +48,7 @@ it('parses the config yaml base file', function () {
                 'queries' => [
                     'explain' => false,
                 ],
-                'profile' => [
+                'profiler' => [
                     'auto_middleware' => false,
                     'max_entries' => 300,
                     'capture' => [

--- a/tests/Feature/SelfHealConfigTest.php
+++ b/tests/Feature/SelfHealConfigTest.php
@@ -48,12 +48,12 @@ it('backfills missing keys into a stale config using the real schema', function 
 
         $written = Yaml::parseFile($file);
 
-        expect($written)->toHaveKeys(['logs', 'profile', 'queries', 'code_snippet', 'xdebug', 'slow_queries']);
-        expect($written['config'])->toHaveKey('color_in_screen');
-        expect($written['profile']['capture'])->toHaveKey('eloquent');
+        expect($written)->toHaveKeys(['logs', 'profiler', 'queries', 'code_snippet', 'xdebug', 'slow_queries'])
+            ->and($written['config'])->toHaveKey('color_in_screen')
+            ->and($written['profiler']['capture'])->toHaveKey('eloquent')
+            ->and($written['app']['project_path'])->toBe('/my/project/')
+            ->and($written['observers']['dump'])->toBeTrue();
 
-        expect($written['app']['project_path'])->toBe('/my/project/');
-        expect($written['observers']['dump'])->toBeTrue();
     });
 });
 
@@ -69,9 +69,9 @@ it('prunes keys that are no longer part of the schema', function () {
 
         $written = Yaml::parseFile($file);
 
-        expect($written['observers'])->not->toHaveKey('obsolete_observer');
-        expect($written)->not->toHaveKey('removed_section');
-        expect($written['app']['project_path'])->toBe('/my/project/');
+        expect($written['observers'])->not->toHaveKey('obsolete_observer')
+            ->and($written)->not->toHaveKey('removed_section')
+            ->and($written['app']['project_path'])->toBe('/my/project/');
     });
 });
 


### PR DESCRIPTION
This pull request standardizes the configuration by renaming the `profile` section to `profiler` across the codebase, configuration files, and tests. This change ensures consistency and clarity in naming, and updates all references to match the new section name.

**Configuration and Code Updates:**

* Renamed the `profile` section to `profiler` in the main configuration file (`laradumps-base.yaml`) and updated all feature flags and nested settings accordingly. [[1]](diffhunk://#diff-dc4778c78ff548d6164ef4c2c6598dccd162064c0a28e0a247fec3ce1276dd7cL17-R17) [[2]](diffhunk://#diff-dc4778c78ff548d6164ef4c2c6598dccd162064c0a28e0a247fec3ce1276dd7cL36-R36)
* Updated all code references from `profile` to `profiler` for configuration lookups, including in `LaraDumpsServiceProvider.php`, `ProfileMiddleware.php`, `ProfileObserver.php`, and `ProfileManager.php`. [[1]](diffhunk://#diff-283b0500f69972f33a0bab567cac1428dfd1d0e919a1fcfac3b400a050a8fa2aL116-R120) [[2]](diffhunk://#diff-8ad1cfb8545bdef0109195e9c28c75e00522a0a1d5c2847e532f025a0ac9ffe8L32-R36) [[3]](diffhunk://#diff-f95cb01315134793929ea0bea13c97226bd85a3b3a2992082ef84dbb08792413L148-R148) [[4]](diffhunk://#diff-0985d074277ebaffe157577fb8b7f9862446cafa9b92c11266e25924c6127189L33-R33) [[5]](diffhunk://#diff-0985d074277ebaffe157577fb8b7f9862446cafa9b92c11266e25924c6127189L60-R69)

**Payload and Screen Naming:**

* Changed the payload and screen type from `'profile'` to `'profiler'` in `ProfilePayload.php` to align with the new naming convention. [[1]](diffhunk://#diff-f1b8ebaadbfd6ff54a8f4c2dd256745da26dacca2929c9be33843f67148b3287L39-R39) [[2]](diffhunk://#diff-f1b8ebaadbfd6ff54a8f4c2dd256745da26dacca2929c9be33843f67148b3287L57-R57)

**Test Updates:**

* Updated all test references to use `profiler` instead of `profile` in configuration structure assertions and expected values, ensuring tests validate the new schema. [[1]](diffhunk://#diff-168ab98671a77963669d8718dd8a9276ab971d64f8c1dc774afd62a2c853e0c3L8-R12) [[2]](diffhunk://#diff-0c7bcb6be6876d8004521ca60d558899625c7aedad1b8b017df3a507c5664a13L27-R27) [[3]](diffhunk://#diff-0c7bcb6be6876d8004521ca60d558899625c7aedad1b8b017df3a507c5664a13L51-R51) [[4]](diffhunk://#diff-3233c547237a5efafae461344f02310d930e47238044184583dfff3e3173d807L51-L56) [[5]](diffhunk://#diff-3233c547237a5efafae461344f02310d930e47238044184583dfff3e3173d807L72-R74)